### PR TITLE
NIAD-1040 Test to show output is in order of bundle not encounter list

### DIFF
--- a/service/src/test/resources/ehr/request/fhir/input/gpc-access-structured.json
+++ b/service/src/test/resources/ehr/request/fhir/input/gpc-access-structured.json
@@ -7654,79 +7654,6 @@
     {
       "resource": {
         "resourceType": "Encounter",
-        "id": "F550CC56-EF65-4934-A7B1-3DC2E02243C3",
-        "meta": {
-          "profile": [
-            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
-          ]
-        },
-        "identifier": [
-          {
-            "system": "https://EMISWeb/A82038",
-            "value": "F550CC56-EF65-4934-A7B1-3DC2E02243C3"
-          }
-        ],
-        "status": "finished",
-        "type": [
-          {
-            "text": "GP Surgery"
-          }
-        ],
-        "subject": {
-          "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
-        },
-        "participant": [
-          {
-            "type": [
-              {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/v3/ParticipationType",
-                    "code": "PPRF",
-                    "display": "primary performer"
-                  }
-                ]
-              }
-            ],
-            "individual": {
-              "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
-            }
-          },
-          {
-            "type": [
-              {
-                "coding": [
-                  {
-                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
-                    "code": "REC",
-                    "display": "recorder"
-                  }
-                ]
-              }
-            ],
-            "individual": {
-              "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
-            }
-          }
-        ],
-        "period": {
-          "start": "2010-01-13T15:20:00+00:00"
-        },
-        "location": [
-          {
-            "location": {
-              "reference": "Location/EB3994A6-5A87-4B53-A414-913137072F57"
-            }
-          }
-        ],
-        "serviceProvider": {
-          "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
-        }
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "Encounter",
         "id": "9B69F6AE-F991-49EE-9FFD-028E39B38BFE",
         "meta": {
           "profile": [
@@ -7784,6 +7711,79 @@
         ],
         "period": {
           "start": "2010-01-23T13:48:00+00:00"
+        },
+        "location": [
+          {
+            "location": {
+              "reference": "Location/EB3994A6-5A87-4B53-A414-913137072F57"
+            }
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "F550CC56-EF65-4934-A7B1-3DC2E02243C3",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://EMISWeb/A82038",
+            "value": "F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "text": "GP Surgery"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/v3/ParticipationType",
+                    "code": "PPRF",
+                    "display": "primary performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+            }
+          }
+        ],
+        "period": {
+          "start": "2010-01-13T15:20:00+00:00"
         },
         "location": [
           {


### PR DESCRIPTION
Changing order of Encounters within the bundle causes ehrComposition to be output in the wrong order