### PR TITLE
NIAD-1427: Remove @contextConductionInd from MedicationStatement components

### DIFF
--- a/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="{{medicationStatementId}}"/>
         <statusCode code="{{statusCode}}"/>

--- a/service/src/main/resources/templates/ehr_medication_statement_prescribe_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_prescribe_template.mustache
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="{{medicationStatementId}}"/>
         <statusCode code="{{statusCode}}"/>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
@@ -198,7 +198,7 @@
             </referredToExternalDocument>
         </reference>
     </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-active-status.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-active-status.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-acute-prescription.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-acute-prescription.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-default-status-reason-code.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-default-status-reason-code.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-no-optional-fields.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-no-optional-fields.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-optional-fields.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-optional-fields.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription-no-value.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription-no-value.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-start-period-only.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-start-period-only.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-complete-status.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-complete-status.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="394559384658936"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-dispense-quantity-text.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-dispense-quantity-text.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-text.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-text.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-value.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-value.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-based-on.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-based-on.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="456"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-no-optional-fields.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-no-optional-fields.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-optional-fields.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-optional-fields.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="394559384658936"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-prior-prescription.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-prescribe-prior-prescription.xml
@@ -1,4 +1,4 @@
-<component typeCode="COMP" contextConductionInd="true">
+<component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="456"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
@@ -619,7 +619,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -698,7 +698,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -778,7 +778,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -858,7 +858,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -938,7 +938,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1018,7 +1018,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1098,7 +1098,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1178,7 +1178,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1258,7 +1258,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1338,7 +1338,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1418,7 +1418,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1498,7 +1498,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1578,7 +1578,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1658,7 +1658,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1738,7 +1738,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1818,7 +1818,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1898,7 +1898,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -1978,7 +1978,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2058,7 +2058,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2138,7 +2138,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2218,7 +2218,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2298,7 +2298,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2378,7 +2378,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2458,7 +2458,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2538,7 +2538,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2618,7 +2618,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2698,7 +2698,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2778,7 +2778,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2858,7 +2858,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -2938,7 +2938,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3018,7 +3018,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3098,7 +3098,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3178,7 +3178,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3258,7 +3258,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3338,7 +3338,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3417,7 +3417,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3497,7 +3497,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3576,7 +3576,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3656,7 +3656,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3736,7 +3736,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3816,7 +3816,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3896,7 +3896,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -3976,7 +3976,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4056,7 +4056,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4136,7 +4136,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4216,7 +4216,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4296,7 +4296,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4376,7 +4376,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4456,7 +4456,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4536,7 +4536,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4616,7 +4616,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4696,7 +4696,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4776,7 +4776,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4855,7 +4855,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -4935,7 +4935,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5014,7 +5014,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5094,7 +5094,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5178,7 +5178,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5262,7 +5262,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5346,7 +5346,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5426,7 +5426,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5506,7 +5506,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5586,7 +5586,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5666,7 +5666,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5746,7 +5746,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5826,7 +5826,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5906,7 +5906,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -5986,7 +5986,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6066,7 +6066,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6146,7 +6146,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6226,7 +6226,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6310,7 +6310,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6390,7 +6390,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6470,7 +6470,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6550,7 +6550,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6630,7 +6630,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6710,7 +6710,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6794,7 +6794,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6878,7 +6878,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -6958,7 +6958,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="ACTIVE"/>
@@ -7042,7 +7042,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>
@@ -7122,7 +7122,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="test-id-3"/>
         <statusCode code="ACTIVE"/>
@@ -7206,7 +7206,7 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="test-id-3"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/uat/output/TC4-9465698490_Daniels_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465698490_Daniels_full_20210119.xml
@@ -420,7 +420,7 @@
     </agentRef>
 </Participant>
     </ObservationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="10B9023B-A997-4449-AF63-EF3015E4C7B5"/>
         <statusCode code="COMPLETE"/>
@@ -529,7 +529,7 @@
     </agentRef>
 </Participant>
     </ObservationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D03E2E72-BE97-411D-9AB1-C6BB53D2BC80"/>
         <statusCode code="COMPLETE"/>
@@ -625,7 +625,7 @@
     </agentRef>
 </Participant>
     </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D81D22B7-5216-44E8-B306-DD542F214792"/>
         <statusCode code="COMPLETE"/>
@@ -709,7 +709,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="9326C01E-488B-4EDF-B9C9-529E69EE0361"/>
         <statusCode code="COMPLETE"/>
@@ -805,7 +805,7 @@
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="CA8DF9CD-0555-4AC3-8852-AFEFC5615854"/>
         <statusCode code="COMPLETE"/>
@@ -914,7 +914,7 @@
     </agentRef>
 </Participant>
     </ObservationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1E5D6932-C778-4997-B624-8709D2FBB189"/>
         <statusCode code="COMPLETE"/>
@@ -996,7 +996,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="72DB5398-C825-4498-88CA-899A3653EC04"/>
         <statusCode code="COMPLETE"/>
@@ -1077,7 +1077,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3D5E3D14-66FD-4E2F-B52F-D30BD253F355"/>
         <statusCode code="COMPLETE"/>
@@ -1158,7 +1158,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E984FD8F-391C-4E6E-9309-1BDE587E23EF"/>
         <statusCode code="ACTIVE"/>
@@ -1239,7 +1239,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="137CDA70-9A78-43E2-930D-2758C7E11D8D"/>
         <statusCode code="ACTIVE"/>
@@ -1320,7 +1320,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D0152980-C786-4D93-B06D-7EE55CAFDDA9"/>
         <statusCode code="COMPLETE"/>
@@ -1402,7 +1402,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="382E9F46-B7A6-4267-BC80-0AAD7E055D00"/>
         <statusCode code="COMPLETE"/>
@@ -1484,7 +1484,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="82A39454-299F-432E-993E-5A6232B4E099"/>
         <statusCode code="ACTIVE"/>
@@ -1565,7 +1565,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="919AE1B8-6BBB-49EF-9FA0-0C04D35BE310"/>
         <statusCode code="COMPLETE"/>
@@ -1647,7 +1647,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F0A2FE75-1856-47AD-9A20-570C9E4CF904"/>
         <statusCode code="ACTIVE"/>
@@ -1728,7 +1728,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="09A882DA-C219-4146-97EF-3FD9A57135B0"/>
         <statusCode code="ACTIVE"/>
@@ -1809,7 +1809,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="97CE760A-7759-4FEA-B5A9-8667E06F86A4"/>
         <statusCode code="COMPLETE"/>
@@ -1891,7 +1891,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="432103E4-651E-417C-97ED-37E4E8649C89"/>
         <statusCode code="ACTIVE"/>
@@ -1972,7 +1972,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DF996C91-D888-4D2D-9D3A-5523480337B1"/>
         <statusCode code="COMPLETE"/>
@@ -2054,7 +2054,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="98E65972-3B3A-48B0-BEF2-F662F905A09F"/>
         <statusCode code="ACTIVE"/>
@@ -2135,7 +2135,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="BC8F0E5D-53ED-45CC-A45C-DE4933E064EF"/>
         <statusCode code="ACTIVE"/>
@@ -2216,7 +2216,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F5392292-A88D-4FC2-8840-A6EBFF39FA46"/>
         <statusCode code="ACTIVE"/>
@@ -2297,7 +2297,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="16A8F240-9B4C-4EFF-9B97-723E341D9AAD"/>
         <statusCode code="COMPLETE"/>
@@ -2379,7 +2379,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="409C8344-FFB9-40C9-A802-D71602F56263"/>
         <statusCode code="COMPLETE"/>
@@ -2473,7 +2473,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="6FB2B95C-55D8-4BF6-A786-1A8465BD4DA9"/>
         <statusCode code="COMPLETE"/>
@@ -2555,7 +2555,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5654E733-A9E5-4086-AD63-3A3C72A8E1B3"/>
         <statusCode code="COMPLETE"/>
@@ -2637,7 +2637,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F599E6DD-92AA-4CC7-BAF0-20530EE1108B"/>
         <statusCode code="COMPLETE"/>
@@ -2719,7 +2719,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="87AEE307-5DEE-4673-BA2E-622376A2DED4"/>
         <statusCode code="COMPLETE"/>
@@ -2813,7 +2813,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3BCD7C65-EC1F-42A1-842F-CA324DB55450"/>
         <statusCode code="COMPLETE"/>
@@ -2895,7 +2895,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="B38C0EDA-1B3C-4456-88F2-EACDE009EB33"/>
         <statusCode code="ACTIVE"/>
@@ -2976,7 +2976,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5DC093EA-05AB-426B-93C9-0D1BAAFAF511"/>
         <statusCode code="COMPLETE"/>
@@ -3058,7 +3058,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C3375CCA-1E80-4F29-AAC1-5D8D27ED605F"/>
         <statusCode code="COMPLETE"/>
@@ -3140,7 +3140,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="AEB66D16-E1FA-462A-BC70-FBD16000E308"/>
         <statusCode code="COMPLETE"/>
@@ -3222,7 +3222,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5DE8CDDA-866F-4CD9-9BB3-527A86DD49A9"/>
         <statusCode code="COMPLETE"/>
@@ -3316,7 +3316,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="088FA6F5-206B-4A4A-AD9A-D95F80C33CCF"/>
         <statusCode code="COMPLETE"/>
@@ -3398,7 +3398,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="689EE4E9-4A30-4007-ADF0-07AAA958C49C"/>
         <statusCode code="COMPLETE"/>
@@ -3479,7 +3479,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="975F5D57-8C97-4E3B-878A-51A6D9F4A03F"/>
         <statusCode code="COMPLETE"/>
@@ -3561,7 +3561,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="98747E87-CAEF-4F64-8CAA-CFC2C61C19BD"/>
         <statusCode code="COMPLETE"/>
@@ -3655,7 +3655,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="46A43153-7A96-44D4-A14A-A63284061767"/>
         <statusCode code="COMPLETE"/>
@@ -3737,7 +3737,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="766D7ECB-0B0B-4593-AFFF-06141F48A998"/>
         <statusCode code="COMPLETE"/>
@@ -3818,7 +3818,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="54BF1314-A4AF-4A19-9BB9-32290AA6718B"/>
         <statusCode code="COMPLETE"/>
@@ -3900,7 +3900,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="A826995B-AB7B-4A63-9B89-FDA16209D357"/>
         <statusCode code="COMPLETE"/>
@@ -3981,7 +3981,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="54AC4831-6E33-4BB9-BC17-33D47E3C8251"/>
         <statusCode code="COMPLETE"/>
@@ -4063,7 +4063,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="A57C161D-E219-4B7F-95AB-D2CDBACECB56"/>
         <statusCode code="COMPLETE"/>
@@ -4144,7 +4144,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7374E13A-D408-460C-A021-3441347C5027"/>
         <statusCode code="COMPLETE"/>
@@ -4226,7 +4226,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="CFF3DAA6-AEE1-44C5-AAA0-BFA72E76B0CE"/>
         <statusCode code="COMPLETE"/>
@@ -4307,7 +4307,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="162EF189-0270-449D-8FE0-BB82E6FF051F"/>
         <statusCode code="COMPLETE"/>
@@ -4389,7 +4389,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7D422F3F-94AE-4D33-8034-E5F4B83ED518"/>
         <statusCode code="COMPLETE"/>
@@ -4470,7 +4470,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F692F966-B4AF-47E7-9F8F-D6ABF7741FA9"/>
         <statusCode code="COMPLETE"/>
@@ -4552,7 +4552,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="B6D2EE2E-D4EA-43C1-9EBB-185802823C27"/>
         <statusCode code="COMPLETE"/>
@@ -4633,7 +4633,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="49259291-5B92-4C0B-BE40-C299A8B02677"/>
         <statusCode code="COMPLETE"/>
@@ -4715,7 +4715,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C41BF66B-5B2D-4493-A2F0-85C0BEABBCA3"/>
         <statusCode code="COMPLETE"/>
@@ -4796,7 +4796,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D32F7C6C-D220-42A1-8028-610E3DEBD991"/>
         <statusCode code="COMPLETE"/>
@@ -4878,7 +4878,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0F6BFE76-8AEC-4FCE-B3FE-8312F7358F42"/>
         <statusCode code="COMPLETE"/>
@@ -4960,7 +4960,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="96167EAF-AC8E-4C48-8A80-AE4DEC414EEB"/>
         <statusCode code="COMPLETE"/>
@@ -5042,7 +5042,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="867553AF-2B39-48F7-BE0B-DE854814CED5"/>
         <statusCode code="COMPLETE"/>
@@ -5123,7 +5123,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4255C920-68D4-46F4-B261-8F2C8D80D3AF"/>
         <statusCode code="COMPLETE"/>
@@ -5205,7 +5205,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="17F48DFB-2DA1-4807-990A-A1CFB6D78C60"/>
         <statusCode code="COMPLETE"/>
@@ -5287,7 +5287,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D20DC48D-2202-4E6A-A1A0-1C6A27C50CAC"/>
         <statusCode code="COMPLETE"/>
@@ -5369,7 +5369,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="266E2D5E-321B-46B9-8CCD-376E335379AB"/>
         <statusCode code="COMPLETE"/>
@@ -5451,7 +5451,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="6CD96448-3DD9-4E6D-857A-798F79824F26"/>
         <statusCode code="COMPLETE"/>
@@ -5533,7 +5533,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1611C14F-3D34-4821-A240-AB09C254DEEA"/>
         <statusCode code="COMPLETE"/>
@@ -5615,7 +5615,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="49C185EE-784C-497C-A7E0-C63A25C057B7"/>
         <statusCode code="COMPLETE"/>
@@ -5697,7 +5697,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F586B623-14FE-4F2B-80D9-953DC28B9828"/>
         <statusCode code="COMPLETE"/>
@@ -5779,7 +5779,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E74F00A1-5189-4806-979F-5A57701BFF13"/>
         <statusCode code="COMPLETE"/>
@@ -5861,7 +5861,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="22E43D5F-BFFE-4336-A9E1-FE9B094996FE"/>
         <statusCode code="COMPLETE"/>
@@ -5943,7 +5943,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="FEB76FD7-EA3E-47AE-9D92-DDB7EB866A99"/>
         <statusCode code="COMPLETE"/>
@@ -6024,7 +6024,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8169ED1C-68A3-410D-B538-BC5AC42C77DA"/>
         <statusCode code="COMPLETE"/>
@@ -6106,7 +6106,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="58B0C2CE-B927-49B5-AB27-B84F278E363B"/>
         <statusCode code="COMPLETE"/>
@@ -6187,7 +6187,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0748F11B-5E47-4F16-A71A-A692EEEA9F45"/>
         <statusCode code="COMPLETE"/>
@@ -6269,7 +6269,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E84D1CA5-D9F2-4189-9509-F6C96A8E1342"/>
         <statusCode code="COMPLETE"/>
@@ -6355,7 +6355,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="2B13FB1D-0FE8-44E2-876B-6AF70F61883C"/>
         <statusCode code="COMPLETE"/>
@@ -6441,7 +6441,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3096EF63-AFC4-4788-9B3A-BEB47E3F4E6B"/>
         <statusCode code="COMPLETE"/>
@@ -6523,7 +6523,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4B331DB8-AC77-4438-A646-56E500E73885"/>
         <statusCode code="COMPLETE"/>
@@ -6605,7 +6605,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="692FAEB8-5071-400B-B689-689F871F58DE"/>
         <statusCode code="COMPLETE"/>
@@ -6687,7 +6687,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="FEA86ABB-8413-4535-ACF8-3EA476B39B53"/>
         <statusCode code="COMPLETE"/>
@@ -6769,7 +6769,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="2CC07C55-8D38-43D0-B3BE-40BCFEC015AA"/>
         <statusCode code="COMPLETE"/>
@@ -6851,7 +6851,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="134493CA-754D-4DDA-A520-20643C17BAF5"/>
         <statusCode code="COMPLETE"/>
@@ -6932,7 +6932,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="79926A25-009B-4D91-BD45-36A87F772FE3"/>
         <statusCode code="COMPLETE"/>
@@ -7014,7 +7014,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EB2F83E0-52B3-424F-9C56-99AAEC53E9D3"/>
         <statusCode code="ACTIVE"/>
@@ -7095,7 +7095,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="9546D5D9-6DB6-47F5-93EE-D7B2F9E63936"/>
         <statusCode code="COMPLETE"/>
@@ -7177,7 +7177,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C86076C5-C69D-45EB-BEC4-1F1B310E80FC"/>
         <statusCode code="ACTIVE"/>
@@ -7258,7 +7258,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E62732A2-87EB-4B91-B61D-BCA1BDC66AB7"/>
         <statusCode code="ACTIVE"/>
@@ -7339,7 +7339,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E24CCAB7-FF1A-4F00-B125-D383D2BA80A1"/>
         <statusCode code="COMPLETE"/>
@@ -7421,7 +7421,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BCADD30D-ED5D-45A0-8D12-7B9C607FDAD8"/>
         <statusCode code="COMPLETE"/>
@@ -7503,7 +7503,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="43F68F4A-CF96-49AF-8BFD-2B89AAD86E4E"/>
         <statusCode code="COMPLETE"/>
@@ -7585,7 +7585,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="2317993E-315F-4AED-B9A7-65D00D23C35D"/>
         <statusCode code="COMPLETE"/>
@@ -7679,7 +7679,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E4E199D1-E516-408C-9D3A-32BD4B9329FA"/>
         <statusCode code="COMPLETE"/>
@@ -7761,7 +7761,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="FBF50073-BA9C-4F3F-922A-C3EBF5E1BB03"/>
         <statusCode code="COMPLETE"/>
@@ -7842,7 +7842,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="619D08A7-F6DA-449B-8609-FF129D688943"/>
         <statusCode code="COMPLETE"/>
@@ -7924,7 +7924,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="4C1B05B8-953E-46A1-8A05-0747DA2C7EDE"/>
         <statusCode code="COMPLETE"/>
@@ -8023,7 +8023,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EE2B87AF-188B-4ECF-97BF-DC5CC69027D9"/>
         <statusCode code="COMPLETE"/>
@@ -8105,7 +8105,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="20C2F7CC-5CF2-4966-8981-80C0E670C316"/>
         <statusCode code="COMPLETE"/>
@@ -8187,7 +8187,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C5676D58-9600-424A-BE35-3DDAE0CAC622"/>
         <statusCode code="ACTIVE"/>
@@ -8268,7 +8268,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7217C8E7-F51A-46B4-8590-6FF88478C7A8"/>
         <statusCode code="COMPLETE"/>
@@ -8362,7 +8362,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5667A85C-4AEF-4431-987D-B29A9A267DD5"/>
         <statusCode code="COMPLETE"/>
@@ -8443,7 +8443,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="4CC234FE-0036-4F39-9E89-AB93FF46DA38"/>
         <statusCode code="COMPLETE"/>
@@ -8524,7 +8524,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="1B1B2854-A658-4764-875B-49CBD3C516EB"/>
         <statusCode code="COMPLETE"/>
@@ -8605,7 +8605,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="74AF9EB7-3E01-46AA-B832-91D29C40C59A"/>
         <statusCode code="COMPLETE"/>
@@ -8687,7 +8687,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="17DC8229-FB0E-4811-A8D0-FAB7D7A05A8C"/>
         <statusCode code="ACTIVE"/>
@@ -8768,7 +8768,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="FE739904-2AAB-4B3F-9718-84BE019FD483"/>
         <statusCode code="COMPLETE"/>
@@ -8850,7 +8850,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="0BB37C2A-AA19-4091-890D-6E0A3D16BDE0"/>
         <statusCode code="COMPLETE"/>
@@ -8944,7 +8944,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F42057DE-87B1-4FB2-97DD-16EE1B61FD58"/>
         <statusCode code="COMPLETE"/>
@@ -9026,7 +9026,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="176ECCF6-93C9-426E-9C10-640DC3C1E86A"/>
         <statusCode code="COMPLETE"/>
@@ -9108,7 +9108,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="36856199-326A-443D-A97B-F744C6A09D10"/>
         <statusCode code="ACTIVE"/>
@@ -9189,7 +9189,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="69C88E7E-45C4-4D52-9BB9-AAB4E62F13FB"/>
         <statusCode code="COMPLETE"/>
@@ -9271,7 +9271,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E5C085B1-363D-49BB-86E7-8283D4D0DD56"/>
         <statusCode code="COMPLETE"/>
@@ -9365,7 +9365,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="06B60CD3-465D-4AEA-A0A8-4A69EA7744CE"/>
         <statusCode code="ACTIVE"/>
@@ -9446,7 +9446,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="AE72CCBA-F60B-46D1-B875-57746102E3A7"/>
         <statusCode code="COMPLETE"/>
@@ -9528,7 +9528,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3390559A-D17E-4D30-9A51-B4459E1515EF"/>
         <statusCode code="COMPLETE"/>
@@ -9609,7 +9609,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="07378FF7-547B-4A4E-9C58-3553095BA37E"/>
         <statusCode code="COMPLETE"/>
@@ -9691,7 +9691,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="FB313646-3FC3-49D0-8277-D11CEA14641D"/>
         <statusCode code="COMPLETE"/>
@@ -9772,7 +9772,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4264DD9C-01B2-4F68-A222-E3B48540496D"/>
         <statusCode code="COMPLETE"/>
@@ -9854,7 +9854,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="BA675192-24E0-4698-8736-00DD928283CB"/>
         <statusCode code="COMPLETE"/>
@@ -9935,7 +9935,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EF7BFB69-2694-46AE-8845-A49B83A88F16"/>
         <statusCode code="COMPLETE"/>
@@ -10017,7 +10017,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="B2342509-6683-4342-8BD1-BB759AAC9BB9"/>
         <statusCode code="COMPLETE"/>
@@ -10098,7 +10098,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="0A4B8365-FEE6-4352-B941-5CCC40F3AE63"/>
         <statusCode code="COMPLETE"/>
@@ -10184,7 +10184,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1E177544-82E7-4D6A-8473-69BC8FC74AB1"/>
         <statusCode code="COMPLETE"/>
@@ -10266,7 +10266,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="D804545A-F8B2-4EDB-9AFE-FD9C2439AE4B"/>
         <statusCode code="ACTIVE"/>
@@ -10352,7 +10352,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="54E82598-8074-4432-AA97-83698B0F3396"/>
         <statusCode code="COMPLETE"/>
@@ -10434,7 +10434,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DF2D442F-9706-41A3-ACE0-A0C06AB49A8A"/>
         <statusCode code="ACTIVE"/>
@@ -10520,7 +10520,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="381D7D39-7FB8-49C2-B042-F15A48B019EB"/>
         <statusCode code="COMPLETE"/>
@@ -10606,7 +10606,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C2CFB5B2-D6CF-4532-AB4F-3C980DD488DC"/>
         <statusCode code="COMPLETE"/>
@@ -10688,7 +10688,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="9C549A51-4365-42A1-871A-F8A76F69B0B9"/>
         <statusCode code="ACTIVE"/>
@@ -10774,7 +10774,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="57AC6A03-EBEE-4C3C-8901-DED3E0BFFF31"/>
         <statusCode code="COMPLETE"/>
@@ -10856,7 +10856,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="60484FAA-43BB-494E-A00F-977364A464BC"/>
         <statusCode code="ACTIVE"/>
@@ -10937,7 +10937,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="218AFE98-B787-45CC-A132-4B281E029F48"/>
         <statusCode code="COMPLETE"/>
@@ -11019,7 +11019,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5D69F207-B9F7-48EB-BDE9-F42CED45357F"/>
         <statusCode code="COMPLETE"/>
@@ -11100,7 +11100,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BCF39DFD-A6ED-43F7-A9BE-5A25EB970C8B"/>
         <statusCode code="COMPLETE"/>
@@ -11182,7 +11182,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="06FF59A7-8E53-4653-BBD9-D5D4350186F0"/>
         <statusCode code="COMPLETE"/>
@@ -11263,7 +11263,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EBFC9E3E-BF6A-4D10-9134-E89BD09006C4"/>
         <statusCode code="COMPLETE"/>
@@ -11345,7 +11345,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="599D6A2F-B001-4E52-A09D-1113D43FA4A0"/>
         <statusCode code="ACTIVE"/>
@@ -11426,7 +11426,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="FFC39E77-6B59-4747-A07C-3A610AFABD22"/>
         <statusCode code="COMPLETE"/>
@@ -11508,7 +11508,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="AB1D8805-56CF-4E9E-89E3-D38EBE871985"/>
         <statusCode code="COMPLETE"/>
@@ -11594,7 +11594,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BF0F48E4-C12E-4BDA-8F55-87219030C7B2"/>
         <statusCode code="COMPLETE"/>
@@ -11676,7 +11676,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C4200E9F-5355-4EFA-A908-602A25619730"/>
         <statusCode code="ACTIVE"/>
@@ -11762,7 +11762,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="90CDA895-C708-4A1D-B880-57DDA978F565"/>
         <statusCode code="COMPLETE"/>
@@ -11844,7 +11844,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7A0397D7-3EAC-4407-92E2-5535EC027F73"/>
         <statusCode code="ACTIVE"/>
@@ -11925,7 +11925,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="15DD9E32-0B6E-4539-93F0-CD7B34B15759"/>
         <statusCode code="COMPLETE"/>
@@ -12007,7 +12007,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="34380A93-1234-41C2-8944-3EDDD2BB9F34"/>
         <statusCode code="COMPLETE"/>
@@ -12088,7 +12088,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F7600EB7-9A46-4AC3-A726-96DEB40E096A"/>
         <statusCode code="COMPLETE"/>
@@ -12170,7 +12170,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E181EBAB-33AC-4A33-80A2-287F462E06A0"/>
         <statusCode code="ACTIVE"/>
@@ -12251,7 +12251,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="01D94EF7-2048-4A7E-8C7E-FD49EB470E93"/>
         <statusCode code="ACTIVE"/>
@@ -12332,7 +12332,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="FF97AC5C-4ABB-4DDB-AE76-DBDEF8A1D452"/>
         <statusCode code="ACTIVE"/>
@@ -12413,7 +12413,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F64CCBEB-A90B-421A-88E8-49B624695441"/>
         <statusCode code="COMPLETE"/>
@@ -12494,7 +12494,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="765AAA6C-96A1-45E0-BBFD-19D887721A93"/>
         <statusCode code="COMPLETE"/>
@@ -12576,7 +12576,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="0A91A8E1-ADF0-4BCB-A51B-3EDCA53C99BA"/>
         <statusCode code="ACTIVE"/>
@@ -12662,7 +12662,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7A10DDA7-9991-4BEC-B51C-41418CE5935A"/>
         <statusCode code="COMPLETE"/>
@@ -12744,7 +12744,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BD4B3AF8-7A36-48B3-B589-881FDC03C47A"/>
         <statusCode code="COMPLETE"/>
@@ -12826,7 +12826,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="07759EED-0A0E-4C8E-906D-832CB079DC78"/>
         <statusCode code="COMPLETE"/>
@@ -12908,7 +12908,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="2C266175-D484-4554-B5D2-46664E36BBF3"/>
         <statusCode code="COMPLETE"/>
@@ -12990,7 +12990,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3714E1B2-F67B-47A3-8B02-32FDCD7D284E"/>
         <statusCode code="COMPLETE"/>
@@ -13072,7 +13072,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="411883E4-1C19-40EE-BFFE-6CD7BB6E4C0B"/>
         <statusCode code="COMPLETE"/>
@@ -13154,7 +13154,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EF07CCC4-EB35-4993-92E9-4C1C1934C7F2"/>
         <statusCode code="ACTIVE"/>
@@ -13235,7 +13235,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="472CE92D-50A5-480E-8E7F-F69276F2A999"/>
         <statusCode code="COMPLETE"/>
@@ -13317,7 +13317,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="904733AD-B296-4F6F-8DDB-A49BFC3066A3"/>
         <statusCode code="COMPLETE"/>
@@ -13399,7 +13399,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="986950DF-9245-40D9-BE24-B0A9132EA679"/>
         <statusCode code="COMPLETE"/>
@@ -13480,7 +13480,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="9978A1BE-97BC-4E0E-A4E1-5285B524FB00"/>
         <statusCode code="COMPLETE"/>
@@ -13562,7 +13562,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DBB2BEBF-D286-48DA-9793-AE7BC666EC8D"/>
         <statusCode code="COMPLETE"/>
@@ -13644,7 +13644,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5E181CAB-9A5F-4667-856F-D37EAF43B1EB"/>
         <statusCode code="COMPLETE"/>
@@ -13726,7 +13726,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="22E2F211-DE10-4DEE-920B-FC9A8163DD66"/>
         <statusCode code="COMPLETE"/>
@@ -13808,7 +13808,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="94D9CCFA-196D-4CC3-BF86-CD8C1A6FFFA6"/>
         <statusCode code="COMPLETE"/>
@@ -13890,7 +13890,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E3B4B58D-DCE9-40D4-8D37-C0719D5CBD76"/>
         <statusCode code="COMPLETE"/>
@@ -13972,7 +13972,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7CA41716-4846-4F94-A9D9-D5E0BD0A82F9"/>
         <statusCode code="COMPLETE"/>
@@ -14054,7 +14054,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E7DD048C-D4FE-4CCF-8CFE-CEC4D87645A7"/>
         <statusCode code="COMPLETE"/>
@@ -14136,7 +14136,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="33F32EF0-5D03-4C4F-801F-C45A12F37ED2"/>
         <statusCode code="COMPLETE"/>
@@ -14218,7 +14218,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C097A760-A532-4898-BE7E-F457AF74A96B"/>
         <statusCode code="COMPLETE"/>
@@ -14300,7 +14300,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="13B6561A-F0BC-4781-BDAF-3DB003A69157"/>
         <statusCode code="COMPLETE"/>
@@ -14394,7 +14394,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F5F629EF-EBC8-4412-84BD-066F1ED71E8C"/>
         <statusCode code="COMPLETE"/>
@@ -14476,7 +14476,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="523D0C41-89F2-41DB-BE1A-56F6165D8DF1"/>
         <statusCode code="COMPLETE"/>
@@ -14557,7 +14557,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4DB1A641-740E-49D8-A498-F44A242DAA7F"/>
         <statusCode code="COMPLETE"/>
@@ -14639,7 +14639,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="72EDBD1D-7797-45F2-ACCF-63C616624FB0"/>
         <statusCode code="COMPLETE"/>
@@ -14720,7 +14720,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A4FF5CDB-FD31-4C11-AB90-2205935377EF"/>
         <statusCode code="COMPLETE"/>
@@ -14802,7 +14802,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="0E63053B-3815-458C-BC48-F55C1C54AAA4"/>
         <statusCode code="COMPLETE"/>
@@ -14883,7 +14883,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F8732698-CF32-4373-B32E-B53FC2B975BF"/>
         <statusCode code="COMPLETE"/>
@@ -14965,7 +14965,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="03D1310D-7E07-4EF8-8C1E-274064340A1A"/>
         <statusCode code="COMPLETE"/>
@@ -15046,7 +15046,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B51C4A24-C5D4-4364-BACF-E2742FEEFFE7"/>
         <statusCode code="COMPLETE"/>
@@ -15128,7 +15128,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="4C3A9569-6A95-4FA4-9FA2-0ED692FE39F7"/>
         <statusCode code="COMPLETE"/>
@@ -15209,7 +15209,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="2AC823BC-2E8D-4183-BA0D-B71E2EAAB113"/>
         <statusCode code="COMPLETE"/>
@@ -15291,7 +15291,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="05AD20D2-5D59-4E3A-8DAE-F3B10C50FA84"/>
         <statusCode code="COMPLETE"/>
@@ -15372,7 +15372,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="9EB9562D-8ACF-4A8F-B0CB-6E37169D3304"/>
         <statusCode code="COMPLETE"/>
@@ -15454,7 +15454,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5E55B187-65DD-447E-902A-AD73AF142A02"/>
         <statusCode code="ACTIVE"/>
@@ -15535,7 +15535,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3F0DCC37-A823-4764-ACD9-BD2B024DE77B"/>
         <statusCode code="COMPLETE"/>
@@ -15616,7 +15616,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="95126292-4EE9-4BAE-8EF2-A58773635AB2"/>
         <statusCode code="COMPLETE"/>
@@ -15698,7 +15698,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="22854E45-B852-455E-B744-B002D06D32F9"/>
         <statusCode code="COMPLETE"/>
@@ -15779,7 +15779,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7BD053C7-97F9-4E1D-BCE6-723ECC6EF7CC"/>
         <statusCode code="COMPLETE"/>
@@ -15861,7 +15861,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F604BE07-5293-408F-871C-163358055486"/>
         <statusCode code="COMPLETE"/>
@@ -15942,7 +15942,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="042B2C37-28A6-4DC3-B3ED-4E8F440A9E77"/>
         <statusCode code="COMPLETE"/>
@@ -16024,7 +16024,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="29841BD8-74E2-442E-88A5-DD1EBF76A10D"/>
         <statusCode code="COMPLETE"/>
@@ -16110,7 +16110,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="4FA2722F-9881-44F1-A0FB-7D47594C1966"/>
         <statusCode code="COMPLETE"/>
@@ -16209,7 +16209,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C9435A8B-BEF8-46DC-9C69-B690D8EA7CC5"/>
         <statusCode code="COMPLETE"/>
@@ -16291,7 +16291,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="64836A3D-C55D-4022-8A33-38D536CF0357"/>
         <statusCode code="COMPLETE"/>
@@ -16373,7 +16373,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A239F1DF-FA6D-44C4-BC0B-F28094896BB4"/>
         <statusCode code="COMPLETE"/>
@@ -16455,7 +16455,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="08C5C565-863E-4FDA-B216-7C1F8DC9E507"/>
         <statusCode code="COMPLETE"/>
@@ -16537,7 +16537,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3AB98D31-BC1C-40C9-B476-3E4012FBD72E"/>
         <statusCode code="COMPLETE"/>
@@ -16619,7 +16619,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C6717B5F-6A72-4962-92BE-0312123E2D94"/>
         <statusCode code="COMPLETE"/>
@@ -16701,7 +16701,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3BBA250A-E619-47D1-8A60-1DD79C0EA87E"/>
         <statusCode code="COMPLETE"/>
@@ -16783,7 +16783,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D66C7EAE-6D74-4FA6-AFCD-DE5B1F51AB1A"/>
         <statusCode code="COMPLETE"/>
@@ -16865,7 +16865,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="037C249B-6739-441B-A054-7E0C0D77E864"/>
         <statusCode code="COMPLETE"/>
@@ -16947,7 +16947,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="01B8713F-C51E-4B4B-90AB-E10584111E65"/>
         <statusCode code="COMPLETE"/>
@@ -17029,7 +17029,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4C654B41-5A11-48A9-A916-67B0342B9C86"/>
         <statusCode code="COMPLETE"/>
@@ -17111,7 +17111,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="8F8A2628-AC4F-4A85-8024-BA23E2898C97"/>
         <statusCode code="COMPLETE"/>
@@ -17197,7 +17197,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EB075CF7-57FC-4363-A517-3AA97414B36E"/>
         <statusCode code="COMPLETE"/>
@@ -17279,7 +17279,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D349E94A-6A48-4F5C-87F7-86D6B2AA2B57"/>
         <statusCode code="COMPLETE"/>
@@ -17361,7 +17361,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="265AA46A-59DC-4527-9532-78B74FCD2E43"/>
         <statusCode code="COMPLETE"/>
@@ -17443,7 +17443,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="400851A1-97BB-427A-86E1-629DBFDAEE38"/>
         <statusCode code="COMPLETE"/>
@@ -17525,7 +17525,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="914D112D-3940-46AA-9C94-47BB6DC366AC"/>
         <statusCode code="COMPLETE"/>
@@ -17607,7 +17607,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0EEA6491-152E-4103-A780-FA3EAA75616E"/>
         <statusCode code="COMPLETE"/>
@@ -17689,7 +17689,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="79403BFE-2F14-4DF5-AE20-60372E2BE1D7"/>
         <statusCode code="COMPLETE"/>
@@ -17771,7 +17771,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="84361836-A537-4936-8DAE-2E13863E8A6A"/>
         <statusCode code="COMPLETE"/>
@@ -17853,7 +17853,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="97612D31-359D-419D-AE25-A60018C52EDC"/>
         <statusCode code="COMPLETE"/>
@@ -17935,7 +17935,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D4843767-1D7E-4057-8567-12F766914B8F"/>
         <statusCode code="COMPLETE"/>
@@ -18017,7 +18017,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7AF79766-2E96-4788-BF5B-20320F3C40CC"/>
         <statusCode code="ACTIVE"/>
@@ -18098,7 +18098,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5A9FE28E-8273-4C90-96E7-6BF4F74E14DE"/>
         <statusCode code="COMPLETE"/>
@@ -18192,7 +18192,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="AC30338B-D591-4AC2-ADE1-890761E9FFC3"/>
         <statusCode code="COMPLETE"/>
@@ -18274,7 +18274,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="900C73DE-AFDE-49ED-B14A-21E0B0091137"/>
         <statusCode code="ACTIVE"/>
@@ -18360,7 +18360,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5B68DC51-CAAA-4BEA-92DB-916BFA22BF42"/>
         <statusCode code="COMPLETE"/>
@@ -18442,7 +18442,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A9069F2F-B34A-40EF-B2DA-74C2A10D0806"/>
         <statusCode code="COMPLETE"/>
@@ -18524,7 +18524,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="CEDFBFCF-FABC-46D6-963D-3622BD85F89A"/>
         <statusCode code="COMPLETE"/>
@@ -18606,7 +18606,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7B0F79B5-41C2-4709-9B35-17C84EAC922A"/>
         <statusCode code="COMPLETE"/>
@@ -18688,7 +18688,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="98BE5C8D-50E1-4C14-A2CA-CB6F8744E2DE"/>
         <statusCode code="COMPLETE"/>
@@ -18770,7 +18770,7 @@
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A28ADA07-2DAE-43D5-BEC2-D2B5F8BB6214"/>
         <statusCode code="COMPLETE"/>
@@ -18852,7 +18852,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DA4FE11D-8CAB-4E14-A8BF-BFA776FBD615"/>
         <statusCode code="COMPLETE"/>
@@ -18946,7 +18946,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5896D8A5-E6A2-4F03-8A26-F783BDF9184C"/>
         <statusCode code="ACTIVE"/>
@@ -19027,7 +19027,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="570E2085-9EF2-4663-8DB1-0B6DD2CF79F6"/>
         <statusCode code="COMPLETE"/>
@@ -19109,7 +19109,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7F820DEC-98A6-4F5F-AE26-1BFA3FB30F0B"/>
         <statusCode code="COMPLETE"/>
@@ -19191,7 +19191,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="09201FE7-F33A-4243-B7B3-0AB634CE076E"/>
         <statusCode code="COMPLETE"/>
@@ -19273,7 +19273,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5D9BE528-E840-4FC4-A370-4E063EB5CE8F"/>
         <statusCode code="COMPLETE"/>
@@ -19355,7 +19355,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8844A2D8-77FF-4E8C-966B-2737FB3BA1E0"/>
         <statusCode code="COMPLETE"/>
@@ -19437,7 +19437,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7C18D682-9E2C-4D77-80FD-6CBA87526662"/>
         <statusCode code="COMPLETE"/>
@@ -19519,7 +19519,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E207BF0E-7F80-4E1C-9BC7-15736EDA421C"/>
         <statusCode code="COMPLETE"/>
@@ -19601,7 +19601,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="61EFA456-F22F-4D0E-BAEC-6A264B5BED6D"/>
         <statusCode code="COMPLETE"/>
@@ -19682,7 +19682,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="8ED56254-7EA1-40E4-BFFE-8FBDB0437BEE"/>
         <statusCode code="COMPLETE"/>
@@ -19781,7 +19781,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="32620463-A64F-496A-8603-E0C5664FFD03"/>
         <statusCode code="COMPLETE"/>
@@ -19863,7 +19863,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="CF33B5B6-0D1A-45A5-A07A-57B75DA2B34E"/>
         <statusCode code="COMPLETE"/>
@@ -19944,7 +19944,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EE9398FB-13BB-4447-97A0-1E363459FE23"/>
         <statusCode code="COMPLETE"/>
@@ -20043,7 +20043,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="49C6FE99-45EE-4735-8371-525D41936752"/>
         <statusCode code="COMPLETE"/>
@@ -20125,7 +20125,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5385DE2A-D791-4C1D-B874-F349685150AD"/>
         <statusCode code="COMPLETE"/>
@@ -20206,7 +20206,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0572BE86-0BF3-4BFB-BA04-3E1DE76CF7C0"/>
         <statusCode code="COMPLETE"/>
@@ -20288,7 +20288,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="8E5B1C8C-F1DD-4D61-A75D-DE6D9DC182A1"/>
         <statusCode code="COMPLETE"/>
@@ -20374,7 +20374,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D12DFD0F-8A39-4ACC-905E-ED6170409DC4"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/uat/output/TC4-9465698679_Gainsford_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465698679_Gainsford_full_20210119.xml
@@ -537,7 +537,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F9EA7B08-5C2D-4F7E-852D-C753F9E8059B"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/uat/output/TC4-9465699918_Magre_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465699918_Magre_full_20210119.xml
@@ -492,7 +492,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8"/>
         <statusCode code="COMPLETE"/>
@@ -576,7 +576,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8F2D066F-E3DB-4D1A-A39F-E19F55A5D6D3"/>
         <statusCode code="COMPLETE"/>
@@ -627,7 +627,7 @@
     </agentRef>
 </Participant>
     </MedicationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8930C6D9-56ED-477A-8407-00DCE8A05DB4"/>
         <statusCode code="COMPLETE"/>
@@ -711,7 +711,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8DF92722-5B5F-4324-866E-0328D5EA4286"/>
         <statusCode code="COMPLETE"/>
@@ -795,7 +795,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DE743503-08D0-4381-903F-8C5691360B54"/>
         <statusCode code="COMPLETE"/>
@@ -891,7 +891,7 @@
     </agentRef>
 </Participant>
     </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4E95E2AF-BF10-45BB-AAA5-2547BD42C806"/>
         <statusCode code="COMPLETE"/>
@@ -1020,7 +1020,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="72DB5398-C825-4498-88CA-899A3653EC04"/>
         <statusCode code="COMPLETE"/>
@@ -1149,7 +1149,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="99792B9D-0715-4F2A-9934-1D5D4E975284"/>
         <statusCode code="COMPLETE"/>
@@ -1233,7 +1233,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="137CDA70-9A78-43E2-930D-2758C7E11D8D"/>
         <statusCode code="COMPLETE"/>
@@ -1317,7 +1317,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0933F2FD-F15D-47FB-9B74-8B48C1A491A4"/>
         <statusCode code="COMPLETE"/>
@@ -1368,7 +1368,7 @@
     </agentRef>
 </Participant>
     </MedicationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="797F53B7-4D96-4BBE-84CC-3110DB040D90"/>
         <statusCode code="COMPLETE"/>
@@ -1452,7 +1452,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BA6EA7CB-3E2F-46FA-918C-C0B5178C1D4E"/>
         <statusCode code="COMPLETE"/>
@@ -1503,7 +1503,7 @@
     </agentRef>
 </Participant>
     </MedicationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C59316B2-2578-412C-8D00-5040C86BF306"/>
         <statusCode code="COMPLETE"/>
@@ -1554,7 +1554,7 @@
     </agentRef>
 </Participant>
     </MedicationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7CB9F236-03CB-4AAD-BB0D-534201961315"/>
         <statusCode code="COMPLETE"/>
@@ -1605,7 +1605,7 @@
     </agentRef>
 </Participant>
     </MedicationStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7B1930D5-A8E5-4843-B8AB-49CD39F484DD"/>
         <statusCode code="COMPLETE"/>
@@ -2413,7 +2413,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5654E733-A9E5-4086-AD63-3A3C72A8E1B3"/>
         <statusCode code="ACTIVE"/>
@@ -2494,7 +2494,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F696636A-F010-4BF6-8AFC-7A0F151E5A5A"/>
         <statusCode code="ACTIVE"/>
@@ -2580,7 +2580,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3A3B1B6F-7DC5-4BE3-A496-0BC243583EBA"/>
         <statusCode code="ACTIVE"/>
@@ -2661,7 +2661,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1610A282-3AF8-4763-BB7A-6F1BB96087DA"/>
         <statusCode code="COMPLETE"/>
@@ -2743,7 +2743,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7AC9EB04-E71D-4E6A-BCCD-3A4A445D91F7"/>
         <statusCode code="COMPLETE"/>
@@ -2824,7 +2824,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="17779BE2-3C37-4DD6-BAA1-3FFEE70B558C"/>
         <statusCode code="ACTIVE"/>
@@ -2905,7 +2905,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5DC093EA-05AB-426B-93C9-0D1BAAFAF511"/>
         <statusCode code="COMPLETE"/>
@@ -2987,7 +2987,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C3375CCA-1E80-4F29-AAC1-5D8D27ED605F"/>
         <statusCode code="COMPLETE"/>
@@ -3081,7 +3081,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DECAA29B-D65A-45B0-805D-EC0BDE3DA971"/>
         <statusCode code="COMPLETE"/>
@@ -3162,7 +3162,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DC14952F-F66E-40D2-B400-0E370E6EDB63"/>
         <statusCode code="COMPLETE"/>
@@ -3243,7 +3243,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EE347F9F-27BB-47C0-BB99-8C613BA277CD"/>
         <statusCode code="ACTIVE"/>
@@ -3324,7 +3324,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="088FA6F5-206B-4A4A-AD9A-D95F80C33CCF"/>
         <statusCode code="COMPLETE"/>
@@ -3406,7 +3406,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="689EE4E9-4A30-4007-ADF0-07AAA958C49C"/>
         <statusCode code="COMPLETE"/>
@@ -3488,7 +3488,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="975F5D57-8C97-4E3B-878A-51A6D9F4A03F"/>
         <statusCode code="COMPLETE"/>
@@ -3570,7 +3570,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="98747E87-CAEF-4F64-8CAA-CFC2C61C19BD"/>
         <statusCode code="COMPLETE"/>
@@ -3652,7 +3652,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="46A43153-7A96-44D4-A14A-A63284061767"/>
         <statusCode code="COMPLETE"/>
@@ -3734,7 +3734,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="766D7ECB-0B0B-4593-AFFF-06141F48A998"/>
         <statusCode code="COMPLETE"/>
@@ -3815,7 +3815,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="018077F0-DA68-4E7D-B3CE-216EFCEFDF8F"/>
         <statusCode code="ACTIVE"/>
@@ -3896,7 +3896,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="142334CE-1D8E-49FF-8A01-D11D5FF8076E"/>
         <statusCode code="COMPLETE"/>
@@ -3978,7 +3978,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="730F742C-1164-45BF-9139-8484074E5995"/>
         <statusCode code="ACTIVE"/>
@@ -4064,7 +4064,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="896104C7-9DC7-4E44-B77D-DB771691C344"/>
         <statusCode code="COMPLETE"/>
@@ -4145,7 +4145,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="0DBC4E2E-3B95-4DD9-A090-055BCFE9371E"/>
         <statusCode code="ACTIVE"/>
@@ -4226,7 +4226,7 @@
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7374E13A-D408-460C-A021-3441347C5027"/>
         <statusCode code="ACTIVE"/>
@@ -4307,7 +4307,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E2E527ED-E7FB-4161-9D3C-04FF121BF267"/>
         <statusCode code="COMPLETE"/>
@@ -4389,7 +4389,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="59C822D8-91DE-47B1-9D4E-08CBCDECD752"/>
         <statusCode code="COMPLETE"/>
@@ -4471,7 +4471,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="AEA7B3B2-06A6-46A6-83B1-188AC5C85E4F"/>
         <statusCode code="COMPLETE"/>
@@ -4553,7 +4553,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="CC922DEF-747F-4162-B790-B3BFF6C258CB"/>
         <statusCode code="COMPLETE"/>
@@ -4635,7 +4635,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3B5DAE5E-D0BC-45E6-A08C-2C01F1A85571"/>
         <statusCode code="COMPLETE"/>
@@ -4717,7 +4717,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5B72BB13-10A8-4AB3-8E13-B2C8428677BB"/>
         <statusCode code="COMPLETE"/>
@@ -4798,7 +4798,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C9C40708-BAC0-4B3C-8B96-EB2C4F0B9800"/>
         <statusCode code="COMPLETE"/>
@@ -4879,7 +4879,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="21F23DE7-D702-4DB4-AD0D-F8A0D56D7537"/>
         <statusCode code="COMPLETE"/>
@@ -4960,7 +4960,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A7E9FEF8-71BC-4A6E-B3D7-94638E59E6B7"/>
         <statusCode code="COMPLETE"/>
@@ -5042,7 +5042,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="180F8AD2-31F1-4399-B481-F527F556AB8E"/>
         <statusCode code="ACTIVE"/>
@@ -5123,7 +5123,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DFC8A57D-1B0C-4EC8-8453-CB7A42A019BD"/>
         <statusCode code="ACTIVE"/>
@@ -5204,7 +5204,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7F80410A-6158-43C4-9E5E-0CFB1F25E781"/>
         <statusCode code="ACTIVE"/>
@@ -5290,7 +5290,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7ED2B987-7AA8-47E1-AAB0-791F65B7AC62"/>
         <statusCode code="COMPLETE"/>
@@ -5372,7 +5372,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="51468E27-23A2-4E47-A341-61A29F1EA4AE"/>
         <statusCode code="ACTIVE"/>
@@ -5458,7 +5458,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="300330A9-5389-444B-A23E-6402355AB06C"/>
         <statusCode code="COMPLETE"/>
@@ -5539,7 +5539,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="89D5E9D7-C45A-4977-A1C9-4B2AB4EC1047"/>
         <statusCode code="COMPLETE"/>
@@ -5621,7 +5621,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="0BA3D29E-065C-4962-9110-036BF07E17C5"/>
         <statusCode code="COMPLETE"/>
@@ -5702,7 +5702,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="9A36A504-E9A3-4FC0-AE0A-B58CD444731B"/>
         <statusCode code="COMPLETE"/>
@@ -5784,7 +5784,7 @@
                 <id root="8D1610C2-5E48-4ED5-882B-5A4A172AFA35"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="4A573C94-BE6C-45F3-A616-4F91A7D18C7D"/>
         <statusCode code="ACTIVE"/>

--- a/service/src/test/resources/uat/output/TC4-9465699926_Sajal_full_20210122.xml
+++ b/service/src/test/resources/uat/output/TC4-9465699926_Sajal_full_20210122.xml
@@ -1518,7 +1518,7 @@
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E984FD8F-391C-4E6E-9309-1BDE587E23EF"/>
         <statusCode code="COMPLETE"/>
@@ -1614,7 +1614,7 @@
     </agentRef>
 </Participant>
     </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
+</component><component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B90A10B6-D8D3-4FDC-A253-5C2CA3350613"/>
         <statusCode code="COMPLETE"/>
@@ -1762,7 +1762,7 @@
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="04AAA10E-3D26-4C86-8932-4BB384C94253"/>
         <statusCode code="COMPLETE"/>
@@ -1846,7 +1846,7 @@
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="85E19135-F780-437D-9633-24BF6C7E5D82"/>
         <statusCode code="COMPLETE"/>
@@ -3885,7 +3885,7 @@ Dosage: 0.5 ml</text>
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5DE8CDDA-866F-4CD9-9BB3-527A86DD49A9"/>
         <statusCode code="COMPLETE"/>
@@ -3966,7 +3966,7 @@ Dosage: 0.5 ml</text>
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="10720133-30C3-4145-9184-8713284C5A90"/>
         <statusCode code="COMPLETE"/>
@@ -4047,7 +4047,7 @@ Dosage: 0.5 ml</text>
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EC6FF2C4-625C-4382-8ED1-B3CD5C512DBF"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/uat/output/TC4-9465700339_Yamura_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465700339_Yamura_full_20210119.xml
@@ -3967,7 +3967,7 @@ with special characters
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EE347F9F-27BB-47C0-BB99-8C613BA277CD"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/uat/output/TC4-9465701262_Meyers_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465701262_Meyers_full_20210119.xml
@@ -1262,7 +1262,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DF71EC06-9453-4AE7-9C3C-E42871252772"/>
         <statusCode code="COMPLETE"/>
@@ -1343,7 +1343,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="99792B9D-0715-4F2A-9934-1D5D4E975284"/>
         <statusCode code="COMPLETE"/>
@@ -1425,7 +1425,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="BDED2793-F5B5-43AC-B8DB-7EA04620CA86"/>
         <statusCode code="COMPLETE"/>
@@ -1519,7 +1519,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8C058D76-FFF1-4EAE-8E82-4351A110A454"/>
         <statusCode code="COMPLETE"/>
@@ -1601,7 +1601,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F4BF142B-6D5C-4E01-933F-A817FD992E9B"/>
         <statusCode code="COMPLETE"/>
@@ -1682,7 +1682,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4209A033-4F0C-490E-8753-607E2799C3D8"/>
         <statusCode code="COMPLETE"/>
@@ -1764,7 +1764,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="85E19135-F780-437D-9633-24BF6C7E5D82"/>
         <statusCode code="COMPLETE"/>
@@ -1850,7 +1850,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F0A2FE75-1856-47AD-9A20-570C9E4CF904"/>
         <statusCode code="COMPLETE"/>
@@ -1932,7 +1932,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="09A882DA-C219-4146-97EF-3FD9A57135B0"/>
         <statusCode code="COMPLETE"/>
@@ -2018,7 +2018,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="97CE760A-7759-4FEA-B5A9-8667E06F86A4"/>
         <statusCode code="COMPLETE"/>
@@ -2104,7 +2104,7 @@
                 <id root="6F7AE308-AD99-48B4-AE9E-72855A6BAA06"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="432103E4-651E-417C-97ED-37E4E8649C89"/>
         <statusCode code="ACTIVE"/>
@@ -2190,7 +2190,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="DF996C91-D888-4D2D-9D3A-5523480337B1"/>
         <statusCode code="COMPLETE"/>
@@ -2271,7 +2271,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E9E90D5A-6E92-4EF0-BB5F-16DE962C93BC"/>
         <statusCode code="COMPLETE"/>
@@ -2357,7 +2357,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BC8F0E5D-53ED-45CC-A45C-DE4933E064EF"/>
         <statusCode code="COMPLETE"/>
@@ -2439,7 +2439,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F5392292-A88D-4FC2-8840-A6EBFF39FA46"/>
         <statusCode code="ACTIVE"/>
@@ -2525,7 +2525,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="16A8F240-9B4C-4EFF-9B97-723E341D9AAD"/>
         <statusCode code="COMPLETE"/>
@@ -2606,7 +2606,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="CA4A0D10-4C71-4E4F-98BF-9023C5F41D21"/>
         <statusCode code="COMPLETE"/>
@@ -2687,7 +2687,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C3A25ECF-E2B2-4861-A649-DC429738F252"/>
         <statusCode code="COMPLETE"/>
@@ -2769,7 +2769,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="00727D84-1710-4A66-A5E9-C419A17ED9C2"/>
         <statusCode code="COMPLETE"/>
@@ -2855,7 +2855,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F696636A-F010-4BF6-8AFC-7A0F151E5A5A"/>
         <statusCode code="COMPLETE"/>
@@ -2937,7 +2937,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3A3B1B6F-7DC5-4BE3-A496-0BC243583EBA"/>
         <statusCode code="COMPLETE"/>
@@ -3023,7 +3023,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E4EC396C-F254-426C-92DA-7DF2AEB8AAC6"/>
         <statusCode code="COMPLETE"/>
@@ -3105,7 +3105,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="BA32A3FF-452C-44A0-9163-3D3AC4F5DD92"/>
         <statusCode code="COMPLETE"/>
@@ -3191,7 +3191,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C34945D5-A784-4742-85EC-7E98AC6AA19C"/>
         <statusCode code="COMPLETE"/>
@@ -3273,7 +3273,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="9276C255-1641-4B9B-AD42-1A0FAD9189D3"/>
         <statusCode code="COMPLETE"/>
@@ -3359,7 +3359,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DECAA29B-D65A-45B0-805D-EC0BDE3DA971"/>
         <statusCode code="COMPLETE"/>
@@ -3441,7 +3441,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F71A6E3B-58E2-4E35-BF01-4B40022E658D"/>
         <statusCode code="COMPLETE"/>
@@ -3527,7 +3527,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="10720133-30C3-4145-9184-8713284C5A90"/>
         <statusCode code="COMPLETE"/>
@@ -3609,7 +3609,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E2E18EA0-392E-43AD-8386-A3D94B2A9235"/>
         <statusCode code="COMPLETE"/>
@@ -3695,7 +3695,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C9FC5F18-F4DD-4B14-B771-1F5E7739CE14"/>
         <statusCode code="COMPLETE"/>
@@ -3777,7 +3777,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="66D4FA62-D07F-4431-B74B-3523D0DCEC17"/>
         <statusCode code="COMPLETE"/>
@@ -3863,7 +3863,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="745FF34E-354F-46DB-A1CA-4D8F48C7DAC7"/>
         <statusCode code="COMPLETE"/>
@@ -3945,7 +3945,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="938365F3-8C68-4189-A550-FAB37F4F59C8"/>
         <statusCode code="COMPLETE"/>
@@ -4031,7 +4031,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="018077F0-DA68-4E7D-B3CE-216EFCEFDF8F"/>
         <statusCode code="COMPLETE"/>
@@ -4113,7 +4113,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="2D265D1D-A7B8-4D9F-9ABE-42F3FFD6305D"/>
         <statusCode code="COMPLETE"/>
@@ -4199,7 +4199,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A9F79684-3214-41E9-A642-A4542875E62B"/>
         <statusCode code="COMPLETE"/>
@@ -4281,7 +4281,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3A6624B4-CC4F-46DF-8051-B739D6ACD920"/>
         <statusCode code="COMPLETE"/>
@@ -4367,7 +4367,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BDD9AD57-8FDA-4DDE-8F88-17BB15BF5ED0"/>
         <statusCode code="COMPLETE"/>
@@ -4449,7 +4449,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="E2E527ED-E7FB-4161-9D3C-04FF121BF267"/>
         <statusCode code="COMPLETE"/>
@@ -4535,7 +4535,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="59C822D8-91DE-47B1-9D4E-08CBCDECD752"/>
         <statusCode code="COMPLETE"/>
@@ -4617,7 +4617,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="AEA7B3B2-06A6-46A6-83B1-188AC5C85E4F"/>
         <statusCode code="COMPLETE"/>
@@ -4703,7 +4703,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="CC922DEF-747F-4162-B790-B3BFF6C258CB"/>
         <statusCode code="COMPLETE"/>
@@ -4785,7 +4785,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="3B5DAE5E-D0BC-45E6-A08C-2C01F1A85571"/>
         <statusCode code="COMPLETE"/>
@@ -4871,7 +4871,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5B72BB13-10A8-4AB3-8E13-B2C8428677BB"/>
         <statusCode code="COMPLETE"/>
@@ -4953,7 +4953,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="8830A1E8-9D50-4A9B-A585-331B7CEBD61F"/>
         <statusCode code="COMPLETE"/>
@@ -5039,7 +5039,7 @@
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="2DCB9D56-5929-467F-A5DF-AA87FF457720"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/uat/output/TC4-9465701297_Livermore_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465701297_Livermore_full_20210119.xml
@@ -1492,7 +1492,7 @@
                 <id root="B65D8AFD-6632-4AEB-9D9F-116149EDD69C"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0933F2FD-F15D-47FB-9B74-8B48C1A491A4"/>
         <statusCode code="COMPLETE"/>
@@ -2746,7 +2746,7 @@
                 <id root="CA4AD477-C33B-4FE7-8417-A242BB3D23AF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="1610A282-3AF8-4763-BB7A-6F1BB96087DA"/>
         <statusCode code="ACTIVE"/>
@@ -2827,7 +2827,7 @@
                 <id root="B65D8AFD-6632-4AEB-9D9F-116149EDD69C"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7AC9EB04-E71D-4E6A-BCCD-3A4A445D91F7"/>
         <statusCode code="ACTIVE"/>
@@ -2913,7 +2913,7 @@
                 <id root="B65D8AFD-6632-4AEB-9D9F-116149EDD69C"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="784D9AB4-B75E-43CE-8370-56DF0D34082C"/>
         <statusCode code="COMPLETE"/>
@@ -2994,7 +2994,7 @@
                 <id root="B65D8AFD-6632-4AEB-9D9F-116149EDD69C"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7AAC20C0-654A-446A-903F-2DFC0AA8B3F8"/>
         <statusCode code="ACTIVE"/>
@@ -3080,7 +3080,7 @@
                 <id root="B65D8AFD-6632-4AEB-9D9F-116149EDD69C"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="116E5A8D-A008-4C23-A8DB-7FD1B8CF24C2"/>
         <statusCode code="COMPLETE"/>
@@ -3161,7 +3161,7 @@
                 <id root="B65D8AFD-6632-4AEB-9D9F-116149EDD69C"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34"/>
         <statusCode code="COMPLETE"/>

--- a/service/src/test/resources/uat/output/TC4-9465701459_Nel_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4-9465701459_Nel_full_20210119.xml
@@ -701,7 +701,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="D81D22B7-5216-44E8-B306-DD542F214792"/>
         <statusCode code="COMPLETE"/>
@@ -782,7 +782,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8DF92722-5B5F-4324-866E-0328D5EA4286"/>
         <statusCode code="COMPLETE"/>
@@ -864,7 +864,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="5F1EDFB9-3B69-4A7A-9D22-26CFE3CD7F1B"/>
         <statusCode code="COMPLETE"/>
@@ -945,7 +945,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="15C6EBEA-F344-443E-BBE9-26B7B8A8F038"/>
         <statusCode code="COMPLETE"/>
@@ -1027,7 +1027,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="6423EA0F-1F1C-4255-AEBA-D142BE836D50"/>
         <statusCode code="COMPLETE"/>
@@ -1108,7 +1108,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="038FC731-8526-4253-8843-9CC9A1EDBD8F"/>
         <statusCode code="COMPLETE"/>
@@ -1190,7 +1190,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EC9F0EBD-415E-4ED6-BA09-C31A807BB7B1"/>
         <statusCode code="COMPLETE"/>
@@ -1272,7 +1272,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C0F4E057-C4A5-481C-BF13-D871D37BD037"/>
         <statusCode code="COMPLETE"/>
@@ -1354,7 +1354,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F9E24109-04D1-4578-9AAD-2C80EA0D17ED"/>
         <statusCode code="COMPLETE"/>
@@ -1436,7 +1436,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B90A10B6-D8D3-4FDC-A253-5C2CA3350613"/>
         <statusCode code="COMPLETE"/>
@@ -1518,7 +1518,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1AB108CA-E906-4055-8F54-7DAED6EE3EBA"/>
         <statusCode code="COMPLETE"/>
@@ -1600,7 +1600,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="04AAA10E-3D26-4C86-8932-4BB384C94253"/>
         <statusCode code="COMPLETE"/>
@@ -1682,7 +1682,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BA6EA7CB-3E2F-46FA-918C-C0B5178C1D4E"/>
         <statusCode code="COMPLETE"/>
@@ -1764,7 +1764,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C59316B2-2578-412C-8D00-5040C86BF306"/>
         <statusCode code="COMPLETE"/>
@@ -1846,7 +1846,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7CB9F236-03CB-4AAD-BB0D-534201961315"/>
         <statusCode code="COMPLETE"/>
@@ -1928,7 +1928,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7B1930D5-A8E5-4843-B8AB-49CD39F484DD"/>
         <statusCode code="COMPLETE"/>
@@ -2010,7 +2010,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="9BA8797D-09D2-43AA-9E81-654B8B15C088"/>
         <statusCode code="COMPLETE"/>
@@ -2092,7 +2092,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="D2B6D4B5-CA07-4CE2-8A0A-40F4FD8CDEF9"/>
         <statusCode code="COMPLETE"/>
@@ -2174,7 +2174,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B99E92D0-1D69-4CF9-A960-3C0B26CAF1AD"/>
         <statusCode code="COMPLETE"/>
@@ -2256,7 +2256,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7884ECD7-033D-433C-BFDE-9D459DA8BC6F"/>
         <statusCode code="COMPLETE"/>
@@ -2338,7 +2338,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="8DD1BB6C-F391-4E1F-B68F-A427448828CA"/>
         <statusCode code="COMPLETE"/>
@@ -2420,7 +2420,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="73CE838C-AB98-4BB2-8C69-4F6508BE99A0"/>
         <statusCode code="COMPLETE"/>
@@ -2502,7 +2502,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="82376D4D-0A24-4B25-9A8A-CC84BEFFDE0D"/>
         <statusCode code="COMPLETE"/>
@@ -2584,7 +2584,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DADBE0C4-2702-4CDC-9BCC-6E3E7C2918B7"/>
         <statusCode code="COMPLETE"/>
@@ -2666,7 +2666,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="3794F0FE-ECA1-4F8C-A321-598FBD1B568C"/>
         <statusCode code="COMPLETE"/>
@@ -2748,7 +2748,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="681FEBF5-6290-4AA0-927C-B1047AE8D21D"/>
         <statusCode code="COMPLETE"/>
@@ -2830,7 +2830,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="47D7EE76-9938-4063-9007-E74B6E92581E"/>
         <statusCode code="COMPLETE"/>
@@ -2912,7 +2912,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="1610A282-3AF8-4763-BB7A-6F1BB96087DA"/>
         <statusCode code="COMPLETE"/>
@@ -2994,7 +2994,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7AC9EB04-E71D-4E6A-BCCD-3A4A445D91F7"/>
         <statusCode code="COMPLETE"/>
@@ -3076,7 +3076,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="784D9AB4-B75E-43CE-8370-56DF0D34082C"/>
         <statusCode code="COMPLETE"/>
@@ -3158,7 +3158,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="E3ABD9D7-736E-47DB-A9A6-97D9898983D8"/>
         <statusCode code="COMPLETE"/>
@@ -3240,7 +3240,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="116E5A8D-A008-4C23-A8DB-7FD1B8CF24C2"/>
         <statusCode code="COMPLETE"/>
@@ -3322,7 +3322,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DC14952F-F66E-40D2-B400-0E370E6EDB63"/>
         <statusCode code="COMPLETE"/>
@@ -3404,7 +3404,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="87102979-C329-4194-819B-D057AAEA625B"/>
         <statusCode code="COMPLETE"/>
@@ -3486,7 +3486,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EC6FF2C4-625C-4382-8ED1-B3CD5C512DBF"/>
         <statusCode code="COMPLETE"/>
@@ -3568,7 +3568,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EE5EF8FB-5B0F-4D22-93E4-6E79489FEF64"/>
         <statusCode code="COMPLETE"/>
@@ -3650,7 +3650,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A53FFA99-F0D7-4395-A4A0-A6A1C5D56D61"/>
         <statusCode code="COMPLETE"/>
@@ -3732,7 +3732,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F8F84A00-B52E-466B-BF66-05C1A49B3F3D"/>
         <statusCode code="COMPLETE"/>
@@ -3814,7 +3814,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="EA0D236C-2CD7-49EB-80D2-9AD58C3969F4"/>
         <statusCode code="COMPLETE"/>
@@ -3895,7 +3895,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="4CF9262A-2676-4973-A45C-2538E5CC93E2"/>
         <statusCode code="COMPLETE"/>
@@ -3977,7 +3977,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="142334CE-1D8E-49FF-8A01-D11D5FF8076E"/>
         <statusCode code="COMPLETE"/>
@@ -4058,7 +4058,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="730F742C-1164-45BF-9139-8484074E5995"/>
         <statusCode code="COMPLETE"/>
@@ -4140,7 +4140,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="896104C7-9DC7-4E44-B77D-DB771691C344"/>
         <statusCode code="COMPLETE"/>
@@ -4222,7 +4222,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="AD55A73E-0A15-48EC-A982-94E8830A90F8"/>
         <statusCode code="COMPLETE"/>
@@ -4304,7 +4304,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="7314452F-9848-403F-8684-D7E0B2163F88"/>
         <statusCode code="COMPLETE"/>
@@ -4386,7 +4386,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BB8DEB7C-BE1B-4639-8213-D94E8FEFA0F6"/>
         <statusCode code="COMPLETE"/>
@@ -4468,7 +4468,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="52D4BB7D-411D-40E5-8C8E-B92088260AFF"/>
         <statusCode code="COMPLETE"/>
@@ -4550,7 +4550,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C0DCF0FF-BB2B-473F-BC5B-2A8C91532824"/>
         <statusCode code="COMPLETE"/>
@@ -4632,7 +4632,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="F91DF279-38D3-47D2-90A9-4C38AECC6DBF"/>
         <statusCode code="COMPLETE"/>
@@ -4714,7 +4714,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="64B21186-BC94-4C6D-A25E-1347666D8DAF"/>
         <statusCode code="COMPLETE"/>
@@ -4796,7 +4796,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="C9C40708-BAC0-4B3C-8B96-EB2C4F0B9800"/>
         <statusCode code="COMPLETE"/>
@@ -4878,7 +4878,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="73A92291-FDB9-4C9A-AF4B-C3080C0230A4"/>
         <statusCode code="COMPLETE"/>
@@ -4960,7 +4960,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="6D3811E2-7FCD-49C2-B5D2-84AB325DA798"/>
         <statusCode code="COMPLETE"/>
@@ -5042,7 +5042,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EA3042F8-1287-46F6-B676-1B07B6AE0E36"/>
         <statusCode code="COMPLETE"/>
@@ -5124,7 +5124,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B32B888D-13A5-4AA9-AA57-66ACD475E145"/>
         <statusCode code="COMPLETE"/>
@@ -5206,7 +5206,7 @@ The line below contains special characters...
                 <id root="CDFC5DF7-2D1B-4EBB-BE5C-6BD2E19405FF"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="452AFD1A-B615-4E2C-A733-544A3426DA24"/>
         <statusCode code="COMPLETE"/>
@@ -5288,7 +5288,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="7ED2B987-7AA8-47E1-AAB0-791F65B7AC62"/>
         <statusCode code="COMPLETE"/>
@@ -5374,7 +5374,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="51468E27-23A2-4E47-A341-61A29F1EA4AE"/>
         <statusCode code="COMPLETE"/>
@@ -5456,7 +5456,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="2DAE1ADC-4B4F-4081-84C4-E93E78346185"/>
         <statusCode code="COMPLETE"/>
@@ -5538,7 +5538,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="89D5E9D7-C45A-4977-A1C9-4B2AB4EC1047"/>
         <statusCode code="COMPLETE"/>
@@ -5620,7 +5620,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="0BA3D29E-065C-4962-9110-036BF07E17C5"/>
         <statusCode code="COMPLETE"/>
@@ -5702,7 +5702,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B16209E7-8BA5-4533-B801-8A82645C6D04"/>
         <statusCode code="COMPLETE"/>
@@ -5784,7 +5784,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="44598FC3-DB57-4303-8B26-7D058F2B3510"/>
         <statusCode code="COMPLETE"/>
@@ -5866,7 +5866,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="155122E0-3D9B-4784-8E29-622A941D8FFC"/>
         <statusCode code="COMPLETE"/>
@@ -5948,7 +5948,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="EC34765C-88BF-42B1-9958-6AF09499FE8C"/>
         <statusCode code="COMPLETE"/>
@@ -6030,7 +6030,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="716B2A02-D779-45A0-812C-B2376C8E6F75"/>
         <statusCode code="COMPLETE"/>
@@ -6112,7 +6112,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="503999C4-17C3-4B14-8085-A995DBC80286"/>
         <statusCode code="COMPLETE"/>
@@ -6194,7 +6194,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="DA602250-41DB-4A8D-B5CB-70863AAF0F2D"/>
         <statusCode code="COMPLETE"/>
@@ -6276,7 +6276,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="F4E72E8A-13BD-4C83-A448-32718731EC94"/>
         <statusCode code="COMPLETE"/>
@@ -6362,7 +6362,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="155DFA49-019C-47F0-9DDE-EA68774988B2"/>
         <statusCode code="COMPLETE"/>
@@ -6444,7 +6444,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="379A459F-11B6-43DB-9083-2C4F0E4F1651"/>
         <statusCode code="COMPLETE"/>
@@ -6526,7 +6526,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="B1310011-B620-48D7-A381-2BF0335C5B3D"/>
         <statusCode code="COMPLETE"/>
@@ -6608,7 +6608,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="14E1EA4E-65C5-423B-A893-BAB8C63551EA"/>
         <statusCode code="COMPLETE"/>
@@ -6690,7 +6690,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="5C8D8F25-DFEB-43B9-A61C-54C86FF0C8CC"/>
         <statusCode code="COMPLETE"/>
@@ -6772,7 +6772,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="CB704DB5-C03E-4AFB-BCE4-C3E8C6BB27E7"/>
         <statusCode code="COMPLETE"/>
@@ -6858,7 +6858,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="A555DD62-B352-45A2-A601-C21F28340B1D"/>
         <statusCode code="COMPLETE"/>
@@ -6940,7 +6940,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="C3FE7EB4-3F56-4C41-A04C-46DA81F4E3A9"/>
         <statusCode code="ACTIVE"/>
@@ -7026,7 +7026,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="BDAD8BDB-770E-4B44-8EEE-79CF187B91A8"/>
         <statusCode code="COMPLETE"/>
@@ -7108,7 +7108,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="INT">
         <id root="4CDE4CDA-36BE-47A3-B6E8-D6BE8C87F394"/>
         <statusCode code="ACTIVE"/>
@@ -7194,7 +7194,7 @@ The line below contains special characters...
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D"/>
             </agentRef>
         </Participant2>
-        <component typeCode="COMP" contextConductionInd="true">
+        <component typeCode="COMP">
     <MedicationStatement classCode="SBADM" moodCode="ORD">
         <id root="85522AAC-80B6-4F73-BD34-50825EF0E45C"/>
         <statusCode code="COMPLETE"/>


### PR DESCRIPTION
https://gpitbjss.atlassian.net/browse/NIAD-1427

Solved with a regex search and replace across the codebase:

Search
`<component typeCode="COMP" contextConductionInd="true">(\s*)<MedicationStatement `

Replace
`<component typeCode="COMP">$1<MedicationStatement `

The capture group and `$1` reference ensure the whitespace between tags is retained.