### PR TITLE
NIAD-1410: Optionalise mappings

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapper.java
@@ -45,9 +45,9 @@ public class DiaryPlanStatementMapper {
     private final MessageContext messageContext;
     private final CodeableConceptCdMapper codeableConceptCdMapper;
 
-    public String mapDiaryProcedureRequestToPlanStatement(ProcedureRequest procedureRequest, Boolean isNested) {
+    public Optional<String> mapDiaryProcedureRequestToPlanStatement(ProcedureRequest procedureRequest, Boolean isNested) {
         if (procedureRequest.getIntent() != ProcedureRequest.ProcedureRequestIntent.PLAN) {
-            return StringUtils.EMPTY;
+            return Optional.empty();
         }
 
         PlanStatementMapperParameters.PlanStatementMapperParametersBuilder builder = PlanStatementMapperParameters.builder()
@@ -59,7 +59,7 @@ public class DiaryPlanStatementMapper {
         buildText(procedureRequest).map(builder::text);
         builder.code(buildCode(procedureRequest));
 
-        return TemplateUtils.fillTemplate(PLAN_STATEMENT_TEMPLATE, builder.build());
+        return Optional.of(TemplateUtils.fillTemplate(PLAN_STATEMENT_TEMPLATE, builder.build()));
     }
 
     private Optional<String> buildEffectiveTime(ProcedureRequest procedureRequest) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -47,7 +47,7 @@ public class EncounterComponentsMapper {
     private static final String NOT_IMPLEMENTED_MAPPER_PLACE_HOLDER = "<!-- %s/%s -->";
     private static final boolean IS_NESTED = false;
 
-    private final Map<ResourceType, Function<Resource, String>> encounterComponents = Map.of(
+    private final Map<ResourceType, Function<Resource, Optional<String>>> encounterComponents = Map.of(
         ResourceType.AllergyIntolerance, this::mapAllergyIntolerance,
         ResourceType.Condition, this::mapCondition,
         ResourceType.DocumentReference, this::mapDocumentReference,
@@ -87,7 +87,7 @@ public class EncounterComponentsMapper {
             .orElse(StringUtils.EMPTY);
     }
 
-    public String mapResourceToComponent(Resource resource) {
+    public Optional<String> mapResourceToComponent(Resource resource) {
         return encounterComponents.getOrDefault(resource.getResourceType(), this::mapDefaultNotImplemented)
             .apply(resource);
     }
@@ -98,10 +98,11 @@ public class EncounterComponentsMapper {
         return listReferencedToEncounter.getEntry()
             .stream()
             .map(this::mapItemToComponent)
+            .flatMap(Optional::stream)
             .collect(Collectors.joining());
     }
 
-    private String mapItemToComponent(ListResource.ListEntryComponent item) {
+    private Optional<String> mapItemToComponent(ListResource.ListEntryComponent item) {
         final String referenceValue = item.getItem().getReference();
         LOGGER.debug("Processing list item {}", referenceValue);
 
@@ -110,7 +111,7 @@ public class EncounterComponentsMapper {
             LOGGER.warn("Detected an invalid reference in the GP Connect Demonstrator dataset. "
                 + "Skipping resource with reference=\"{}\" display=\"{}\"", referenceValue,
                 item.getItem().getDisplay());
-            return StringUtils.EMPTY;
+            return Optional.empty();
         }
 
         Resource resource = messageContext.getInputBundleHolder().getRequiredResource(item.getItem().getReferenceElement());
@@ -122,59 +123,61 @@ public class EncounterComponentsMapper {
         }
     }
 
-    private String mapDefaultNotImplemented(Resource resource) {
-        return String.format(NOT_IMPLEMENTED_MAPPER_PLACE_HOLDER,
+    private Optional<String> mapDefaultNotImplemented(Resource resource) {
+        return Optional.of(String.format(NOT_IMPLEMENTED_MAPPER_PLACE_HOLDER,
             resource.getIdElement().getResourceType(),
-            resource.getIdElement().getIdPart());
+            resource.getIdElement().getIdPart()));
     }
 
-    private String mapAllergyIntolerance(Resource resource) {
-        return allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure((AllergyIntolerance) resource);
+    private Optional<String> mapAllergyIntolerance(Resource resource) {
+        return Optional.of(allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure((AllergyIntolerance) resource));
     }
 
-    private String mapCondition(Resource resource) {
-        return conditionLinkSetMapper.mapConditionToLinkSet((Condition) resource, IS_NESTED);
+    private Optional<String> mapCondition(Resource resource) {
+        return Optional.of(conditionLinkSetMapper.mapConditionToLinkSet((Condition) resource, IS_NESTED));
     }
 
-    private String mapDocumentReference(Resource resource) {
-        return documentReferenceToNarrativeStatementMapper.mapDocumentReferenceToNarrativeStatement((DocumentReference) resource);
+    private Optional<String> mapDocumentReference(Resource resource) {
+        return Optional.of(
+            documentReferenceToNarrativeStatementMapper.mapDocumentReferenceToNarrativeStatement((DocumentReference) resource));
     }
 
-    private String mapImmunization(Resource resource) {
-        return immunizationObservationStatementMapper.mapImmunizationToObservationStatement((Immunization) resource, IS_NESTED);
+    private Optional<String> mapImmunization(Resource resource) {
+        return Optional.of(
+            immunizationObservationStatementMapper.mapImmunizationToObservationStatement((Immunization) resource, IS_NESTED));
     }
 
-    private String mapListResource(Resource resource) {
+    private Optional<String> mapListResource(Resource resource) {
         ListResource listResource = (ListResource) resource;
 
         if (listResource.hasEntry() && CodeableConceptMappingUtils.hasCode(listResource.getCode(), COMPONENTS_LISTS)) {
-            return mapListResourceToComponents(listResource);
+            return Optional.of(mapListResourceToComponents(listResource));
         }
 
-        return StringUtils.EMPTY;
+        return Optional.empty();
     }
 
-    private String mapMedicationRequest(Resource resource) {
-        return medicationStatementMapper.mapMedicationRequestToMedicationStatement((MedicationRequest) resource);
+    private Optional<String> mapMedicationRequest(Resource resource) {
+        return Optional.of(medicationStatementMapper.mapMedicationRequestToMedicationStatement((MedicationRequest) resource));
     }
 
-    private String mapObservation(Resource resource) {
+    private Optional<String> mapObservation(Resource resource) {
         Observation observation = (Observation) resource;
         if (CodeableConceptMappingUtils.hasCode(observation.getCode(), List.of(NARRATIVE_STATEMENT_CODE))) {
-            return observationToNarrativeStatementMapper.mapObservationToNarrativeStatement(observation, IS_NESTED);
+            return Optional.of(observationToNarrativeStatementMapper.mapObservationToNarrativeStatement(observation, IS_NESTED));
         }
         if (CodeableConceptMappingUtils.hasCode(observation.getCode(), BLOOD_CODES)) {
-            return bloodPressureMapper.mapBloodPressure(observation, IS_NESTED);
+            return Optional.of(bloodPressureMapper.mapBloodPressure(observation, IS_NESTED));
         }
 
-        return observationStatementMapper.mapObservationToObservationStatement(observation, IS_NESTED);
+        return Optional.of(observationStatementMapper.mapObservationToObservationStatement(observation, IS_NESTED));
     }
 
-    private String mapProcedureRequest(Resource resource) {
+    private Optional<String> mapProcedureRequest(Resource resource) {
         return diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement((ProcedureRequest) resource, IS_NESTED);
     }
 
-    private String mapReferralRequest(Resource resource) {
-        return requestStatementMapper.mapReferralRequestToRequestStatement((ReferralRequest) resource, IS_NESTED);
+    private Optional<String> mapReferralRequest(Resource resource) {
+        return Optional.of(requestStatementMapper.mapReferralRequestToRequestStatement((ReferralRequest) resource, IS_NESTED));
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/NonConsultationResourceMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/NonConsultationResourceMapper.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Resource;
@@ -79,14 +78,15 @@ public class NonConsultationResourceMapper {
     }
 
     private Optional<String> mapResourceToEhrComposition(Resource resource) {
-        String component = encounterComponentsMapper.mapResourceToComponent(resource);
+        Optional<String> componentHolder = encounterComponentsMapper.mapResourceToComponent(resource);
 
-        // TODO: workaround for NIAD-1410, should the mapper output ever be blank?
-        if (StringUtils.isBlank(component)) {
-            LOGGER.warn("Skipping {}. The mapping output contains blank XML statement content", resource.getResourceType());
+        if (componentHolder.isEmpty()) {
+            LOGGER.warn("Skipping {} with ID '{}'. The mapping output contains blank XML statement content",
+                resource.getResourceType(), resource.getId());
             return Optional.empty();
         }
 
+        String component = componentHolder.get();
         EncounterTemplateParametersBuilder builder;
         if (resource.getResourceType().equals(ResourceType.Observation)) {
             builder = buildForObservation(component, (Observation) resource);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
@@ -87,7 +87,7 @@ public class DiaryPlanStatementMapperTest {
         ProcedureRequest inputProcedureRequest = new FhirParseService().parseResource(inputJson, ProcedureRequest.class);
 
         var mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, true);
-        assertThat(mappedXml).hasValueSatisfying(xml -> assertThat(xml).isEqualToIgnoringWhitespace(expectedXml));
+        assertThat(mappedXml).contains(expectedXml);
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
@@ -86,8 +86,8 @@ public class DiaryPlanStatementMapperTest {
         String inputJson = ResourceTestFileUtils.getFileContent(INPUT_PROCEDURE_REQUEST_WITH_ALL_DATA);
         ProcedureRequest inputProcedureRequest = new FhirParseService().parseResource(inputJson, ProcedureRequest.class);
 
-        String mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, true);
-        assertThat(mappedXml).isEqualToIgnoringWhitespace(expectedXml);
+        var mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, true);
+        assertThat(mappedXml).hasValueSatisfying(xml -> assertThat(xml).isEqualToIgnoringWhitespace(expectedXml));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class DiaryPlanStatementMapperTest {
         String inputJson = ResourceTestFileUtils.getFileContent(INPUT_PROCEDURE_REQUEST_IS_NOT_PLAN);
         ProcedureRequest inputProcedureRequest = new FhirParseService().parseResource(inputJson, ProcedureRequest.class);
 
-        String mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, true);
+        var mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, true);
         assertThat(mappedXml).isEmpty();
     }
 
@@ -116,8 +116,8 @@ public class DiaryPlanStatementMapperTest {
         String inputJson = ResourceTestFileUtils.getFileContent(inputJsonPath);
         ProcedureRequest inputProcedureRequest = new FhirParseService().parseResource(inputJson, ProcedureRequest.class);
 
-        String mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, false);
-        assertThat(mappedXml).isEqualTo(expectedXml);
+        var mappedXml = diaryPlanStatementMapper.mapDiaryProcedureRequestToPlanStatement(inputProcedureRequest, false);
+        assertThat(mappedXml).contains(expectedXml);
     }
 
     private static Stream<Arguments> testData() {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/NonConsultationResourceMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/NonConsultationResourceMapperTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
@@ -107,7 +108,8 @@ public class NonConsultationResourceMapperTest {
     }
 
     private void setupMock(String stubEhrComponentMapperXml) {
-        when(encounterComponentsMapper.mapResourceToComponent(any(Resource.class))).thenReturn(stubEhrComponentMapperXml);
+        when(encounterComponentsMapper.mapResourceToComponent(any(Resource.class)))
+            .thenReturn(Optional.of(stubEhrComponentMapperXml));
         nonConsultationResourceMapper = new NonConsultationResourceMapper(messageContext,
             randomIdGeneratorService,
             encounterComponentsMapper);


### PR DESCRIPTION
The workaround was deemed the appropriate way to handle the situation of a
mapper returning empty/blank values. However, empty `Optional`s were taken
as an improvement over possibly-blank strings.