### PR TITLE
NIAD-1166 Create a dispatcher for 'Send NACK message' task

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskType.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskType.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition;
 import uk.nhs.adaptors.gp2gp.ehr.SendDocumentTaskDefinition;
 import uk.nhs.adaptors.gp2gp.ehr.SendEhrExtractCoreTaskDefinition;
+import uk.nhs.adaptors.gp2gp.ehr.SendNegativeAcknowledgementTaskDefinition;
 import uk.nhs.adaptors.gp2gp.gpc.GetGpcDocumentReferencesTaskDefinition;
 import uk.nhs.adaptors.gp2gp.gpc.GetGpcDocumentTaskDefinition;
 import uk.nhs.adaptors.gp2gp.gpc.GetGpcStructuredTaskDefinition;
@@ -17,7 +18,8 @@ public enum TaskType {
     GPC_FIND_DOCUMENTS(GetGpcDocumentReferencesTaskDefinition.class),
     SEND_EHR_EXTRACT_CORE(SendEhrExtractCoreTaskDefinition.class),
     SEND_EHR_CONTINUE(SendDocumentTaskDefinition.class),
-    SEND_ACKNOWLEDGEMENT(SendAcknowledgementTaskDefinition.class);
+    SEND_ACKNOWLEDGEMENT(SendAcknowledgementTaskDefinition.class),
+    SEND_NEGATIVE_ACKNOWLEDGEMENT(SendNegativeAcknowledgementTaskDefinition.class);
 
     private final Class<? extends TaskDefinition> classOfTaskDefinition;
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendNegativeAcknowledgementTaskDefinition.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendNegativeAcknowledgementTaskDefinition.java
@@ -1,0 +1,26 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import uk.nhs.adaptors.gp2gp.common.task.TaskDefinition;
+import uk.nhs.adaptors.gp2gp.common.task.TaskType;
+
+import static uk.nhs.adaptors.gp2gp.common.task.TaskType.SEND_NEGATIVE_ACKNOWLEDGEMENT;
+
+@Jacksonized
+@SuperBuilder
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class SendNegativeAcknowledgementTaskDefinition extends TaskDefinition {
+    private final String typeCode;
+    private final String ehrRequestMessageId;
+    private final String reasonCode;
+    private final String detail;
+
+    @Override
+    public TaskType getTaskType() {
+        return SEND_NEGATIVE_ACKNOWLEDGEMENT;
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendNegativeAcknowledgementTaskDispatcher.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendNegativeAcknowledgementTaskDispatcher.java
@@ -1,0 +1,44 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
+import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
+import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class SendNegativeAcknowledgementTaskDispatcher {
+    private static final String NACK_TYPE_CODE = "AE";
+
+    private final TaskDispatcher taskDispatcher;
+    private final RandomIdGeneratorService randomIdGeneratorService;
+
+    public void sendNegativeAcknowledgement(EhrExtractStatus ehrExtractStatus, String reasonCode, String reasonMessage) {
+        var ehrRequest = ehrExtractStatus.getEhrRequest();
+        var sendAcknowledgementTaskDefinition = SendNegativeAcknowledgementTaskDefinition.builder()
+            .taskId(randomIdGeneratorService.createNewId())
+            .conversationId(ehrExtractStatus.getConversationId())
+            .requestId(ehrRequest.getRequestId())
+            .toAsid(ehrRequest.getToAsid())
+            .fromAsid(ehrRequest.getFromAsid())
+            .fromOdsCode(ehrRequest.getFromOdsCode())
+            .toOdsCode(ehrRequest.getToOdsCode())
+            .reasonCode(reasonCode)
+            .detail(reasonMessage)
+            .typeCode(NACK_TYPE_CODE)
+            .ehrRequestMessageId(ehrRequest.getMessageId())
+            .build();
+
+        taskDispatcher.createTask(sendAcknowledgementTaskDefinition);
+
+        LOGGER.info(
+            "SendNegativeAcknowledgementTask added to task queue for Conversation-Id {}",
+            ehrExtractStatus.getConversationId()
+        );
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/SendNegativeAcknowledgementTaskDispatcherTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/SendNegativeAcknowledgementTaskDispatcherTest.java
@@ -1,0 +1,94 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
+import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
+import uk.nhs.adaptors.gp2gp.common.task.TaskType;
+import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SendNegativeAcknowledgementTaskDispatcherTest {
+
+    private static final String CONVERSATION_ID = "bc96655f-1b24-4772-ace6-c31f4d80ff58";
+    private static final String REQUEST_ID = "0c812331-fb6e-4c67-b6d5-9d99022e559f";
+    private static final String MESSAGE_ID = "a407194a-1a15-41ff-9dc6-72b92739c422";
+    private static final String TO_ASID = "200000000359";
+    private static final String FROM_ASID = "918999198738";
+    private static final String FROM_ODS_CODE = "GPC001";
+    private static final String TO_ODS_CODE = "GPC002";
+    private static final String NACK_TYPE_CODE = "AE";
+
+    @Mock
+    private TaskDispatcher taskDispatcher;
+    @Mock
+    private RandomIdGeneratorService randomIdGeneratorService;
+
+    @Captor
+    private ArgumentCaptor<SendNegativeAcknowledgementTaskDefinition> taskDefinitionArgumentCaptor;
+
+    private SendNegativeAcknowledgementTaskDispatcher sendNackTaskDispatcher;
+
+    @BeforeEach
+    public void setUp() {
+        this.sendNackTaskDispatcher = new SendNegativeAcknowledgementTaskDispatcher(
+            taskDispatcher,
+            randomIdGeneratorService
+        );
+    }
+
+    @Test
+    public void When_Called_Expect_TaskTriggeredWithCorrectDefinitionProvided() {
+        // ARRANGE
+        var reasonCode = "reasonCode1";
+        var reasonMessage = "reasonMessage1";
+
+        var taskId = "f41fa0a6-0529-4451-b15d-38584e9f0080";
+        when(randomIdGeneratorService.createNewId()).thenReturn(taskId);
+
+        // ACT
+        sendNackTaskDispatcher.sendNegativeAcknowledgement(sampleEhrExtractStatus(), reasonCode, reasonMessage);
+
+        // ASSERT
+        verify(taskDispatcher).createTask(taskDefinitionArgumentCaptor.capture());
+
+        SendNegativeAcknowledgementTaskDefinition definition = taskDefinitionArgumentCaptor.getValue();
+
+        assertThat(definition.getConversationId()).isEqualTo(CONVERSATION_ID);
+        assertThat(definition.getRequestId()).isEqualTo(REQUEST_ID);
+        assertThat(definition.getToAsid()).isEqualTo(TO_ASID);
+        assertThat(definition.getFromAsid()).isEqualTo(FROM_ASID);
+        assertThat(definition.getToOdsCode()).isEqualTo(TO_ODS_CODE);
+        assertThat(definition.getFromOdsCode()).isEqualTo(FROM_ODS_CODE);
+        assertThat(definition.getTaskType()).isEqualTo(TaskType.SEND_NEGATIVE_ACKNOWLEDGEMENT);
+        assertThat(definition.getEhrRequestMessageId()).isEqualTo(MESSAGE_ID);
+        assertThat(definition.getTypeCode()).isEqualTo(NACK_TYPE_CODE);
+
+        assertThat(definition.getReasonCode()).isEqualTo(reasonCode);
+        assertThat(definition.getDetail()).isEqualTo(reasonMessage);
+        assertThat(definition.getTaskId()).isEqualTo(taskId);
+    }
+
+    private EhrExtractStatus sampleEhrExtractStatus() {
+        return EhrExtractStatus.builder()
+            .conversationId(CONVERSATION_ID)
+            .ehrRequest(EhrExtractStatus.EhrRequest.builder()
+                .requestId(REQUEST_ID)
+                .fromAsid(FROM_ASID)
+                .toAsid(TO_ASID)
+                .fromOdsCode(FROM_ODS_CODE)
+                .toOdsCode(TO_ODS_CODE)
+                .messageId(MESSAGE_ID)
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
Create a dispatcher for 'Send NACK message' task, along with task definition.

This is a part of the bigger change, which as a whole can be found here: https://github.com/nhsconnect/integration-adaptor-gp2gp/pull/260