### PR TITLE
NIAD-1166 Verify that message processing is aborted when message can't be read

### DIFF
--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/mhs/InboundMessageHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/mhs/InboundMessageHandlerTest.java
@@ -65,21 +65,37 @@ public class InboundMessageHandlerTest {
 
     @Test
     @SneakyThrows
-    public void When_MessageIsUnreadable_Expect_FalseToBeReturned() {
+    public void When_MessageIsUnreadable_Expect_MessageProcessingToBeAborted() {
         doThrow(mock(JMSException.class)).when(message).getBody(String.class);
 
         var result = inboundMessageHandler.handle(message);
         assertThat(result).isFalse();
+
+        verifyNoInteractions(ehrExtractRequestHandler, mdcService, processFailureHandlingService);
     }
 
     @Test
     @SneakyThrows
-    public void When_MessageIsNotJson_Expect_FalseToBeReturned() {
+    public void When_MessageIsNotJson_Expect_MessageProcessingToBeAborted() {
         when(message.getBody(String.class)).thenReturn(BODY_NOT_JSON);
         doThrow(mock(JsonProcessingException.class)).when(objectMapper).readValue(BODY_NOT_JSON, InboundMessage.class);
 
         var result = inboundMessageHandler.handle(message);
         assertThat(result).isFalse();
+
+        verifyNoInteractions(ehrExtractRequestHandler, mdcService, processFailureHandlingService);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_ExceptionIsThrownWhenParsingTheMessage_Expect_MessageProcessingToBeAborted() {
+        setUpEhrExtract(EBXML_CONTENT);
+        doThrow(RuntimeException.class).when(xPathService).parseDocumentFromXml(any());
+
+        var result = inboundMessageHandler.handle(message);
+
+        assertThat(result).isFalse();
+        verifyNoInteractions(ehrExtractRequestHandler, mdcService, processFailureHandlingService);
     }
 
     @Test
@@ -91,8 +107,9 @@ public class InboundMessageHandlerTest {
         doReturn(header).when(xPathService).parseDocumentFromXml(EBXML_CONTENT);
         doReturn(payload).when(xPathService).parseDocumentFromXml(PAYLOAD_CONTENT);
 
-        inboundMessageHandler.handle(message);
+        var result = inboundMessageHandler.handle(message);
 
+        assertThat(result).isTrue();
         verify(ehrExtractRequestHandler).handleStart(header, payload);
     }
 
@@ -105,8 +122,9 @@ public class InboundMessageHandlerTest {
         doReturn(header).when(xPathService).parseDocumentFromXml(EBXML_CONTENT);
         doReturn(payload).when(xPathService).parseDocumentFromXml(PAYLOAD_CONTENT);
 
-        inboundMessageHandler.handle(message);
+        var result = inboundMessageHandler.handle(message);
 
+        assertThat(result).isTrue();
         verify(ehrExtractRequestHandler).handleAcknowledgement("75049C80-5271-11EA-9384-E83935108FD5", payload);
     }
 


### PR DESCRIPTION
Extend unit tests to verify that message processing is aborted when message can't be read.