### PR TITLE
NIAD-1166: create integration tests for the handling of inbound messages

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/InboundMessageHandlingTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/InboundMessageHandlingTest.java
@@ -1,0 +1,184 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.CONVERSATION_ID;
+
+import javax.jms.Message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.SneakyThrows;
+import uk.nhs.adaptors.gp2gp.common.service.XPathService;
+import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
+import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.mhs.InboundMessage;
+import uk.nhs.adaptors.gp2gp.mhs.InboundMessageConsumer;
+import uk.nhs.adaptors.gp2gp.testcontainers.ActiveMQExtension;
+import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
+
+@RunWith(SpringRunner.class)
+@ExtendWith({SpringExtension.class, MongoDBExtension.class, ActiveMQExtension.class, MockitoExtension.class})
+@SpringBootTest
+@DirtiesContext
+public class InboundMessageHandlingTest {
+    private static final String CONTINUE_INTERACTION_ID = "COPC_IN000001UK01";
+    private static final String ACTION_PATH = "/Envelope/Header/MessageHeader/Action";
+    private static final String CONVERSATION_ID_PATH = "/Envelope/Header/MessageHeader/ConversationId";
+    private static final String CONTINUE_MESSAGE_PAYLOAD = "Continue Acknowledgement";
+
+    @MockBean
+    private XPathService xPathService;
+    @MockBean
+    private ObjectMapper objectMapper;
+    @MockBean
+    private TaskDispatcher taskDispatcher;
+    @Autowired
+    private InboundMessageConsumer inboundMessageConsumer;
+    @Autowired
+    private EhrExtractStatusRepository ehrExtractStatusRepository;
+    @Mock
+    private Message message;
+    @Mock
+    private InboundMessage inboundMessage;
+
+    @Test
+    @SneakyThrows
+    public void When_MessageIsUnreadable_Expect_MessageProcessingToBeAborted() {
+        mockNonJsonMessage();
+
+        inboundMessageConsumer.receive(message);
+
+        verify(message, never()).acknowledge();
+        verifyNoInteractions(taskDispatcher);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_MessageProcessingFails_Expect_WholeProcessToBeFailed() {
+        // ARRANGE
+        mockInboundMessage("unsupportedInteractionId", CONTINUE_MESSAGE_PAYLOAD);
+
+        var ehrExtractStatus = EhrExtractStatusTestUtils.prepareEhrExtractStatus();
+        ehrExtractStatusRepository.save(ehrExtractStatus);
+
+        // ACT
+        inboundMessageConsumer.receive(message);
+
+        // ASSERT
+        verify(message).acknowledge();
+        assertThatSendNackTaskHasBeenTriggered();
+        assertConversationIsFailed(ehrExtractStatus);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_ProcessIsAlreadyFailed_Expect_MessageProcessingToBeAborted() {
+        // ARRANGE
+        mockInboundMessage(CONTINUE_INTERACTION_ID, CONTINUE_MESSAGE_PAYLOAD);
+
+        var ehrExtractStatus = EhrExtractStatusTestUtils.prepareEhrExtractStatus();
+        ehrExtractStatus.setError(EhrExtractStatus.Error.builder().build());
+        ehrExtractStatusRepository.save(ehrExtractStatus);
+
+        var initialDbExtract = readEhrExtractStatusFromDb();
+
+        // ACT
+        inboundMessageConsumer.receive(message);
+
+        // ASSERT
+        verify(message).acknowledge();
+        verifyNoInteractions(taskDispatcher);
+
+        var finalDbExtract = ehrExtractStatusRepository.findByConversationId(ehrExtractStatus.getConversationId()).get();
+        assertThat(finalDbExtract).usingRecursiveComparison().isEqualTo(initialDbExtract);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_ProcessIsNotFailed_Expect_MessageToBeProcessed() {
+        // ARRANGE
+        mockInboundMessage(CONTINUE_INTERACTION_ID, CONTINUE_MESSAGE_PAYLOAD);
+        ehrExtractStatusRepository.save(EhrExtractStatusTestUtils.prepareEhrExtractStatus());
+
+        var initialDbExtract = readEhrExtractStatusFromDb();
+        assertThat(initialDbExtract.getEhrContinue()).isNull();
+
+        // ACT
+        inboundMessageConsumer.receive(message);
+
+        // ASSERT
+        verify(message).acknowledge();
+        assertSendDocumentTaskHasBeenTriggered();
+
+        var finalDbExtract = readEhrExtractStatusFromDb();
+        assertThat(finalDbExtract.getEhrContinue()).isNotNull();
+        assertThat(finalDbExtract.getError()).isNull();
+    }
+
+    private void assertConversationIsFailed(EhrExtractStatus ehrExtractStatus) {
+        var dbExtract = ehrExtractStatusRepository.findByConversationId(ehrExtractStatus.getConversationId()).get();
+        assertThat(dbExtract.getError()).isNotNull();
+    }
+
+    private void assertThatSendNackTaskHasBeenTriggered() {
+        var ackDefinitionCaptor = ArgumentCaptor.forClass(SendAcknowledgementTaskDefinition.class);
+        verify(taskDispatcher).createTask(ackDefinitionCaptor.capture());
+        verifyNoMoreInteractions(taskDispatcher);
+
+        assertThat(ackDefinitionCaptor.getValue().isNack()).isTrue();
+    }
+
+    private void assertSendDocumentTaskHasBeenTriggered() {
+        var sendDocumentTaskDefinitionCaptor = ArgumentCaptor.forClass(SendDocumentTaskDefinition.class);
+        verify(taskDispatcher).createTask(sendDocumentTaskDefinitionCaptor.capture());
+    }
+
+    @SneakyThrows
+    private void mockNonJsonMessage() {
+        doThrow(JsonProcessingException.class)
+            .when(objectMapper)
+            .readValue(
+                ArgumentMatchers.<String>any(),
+                ArgumentMatchers.<Class<InboundMessage>>any()
+            );
+    }
+
+    @SneakyThrows
+    private void mockInboundMessage(String interactionId, String payload) {
+        when(
+            objectMapper.readValue(ArgumentMatchers.<String>any(), ArgumentMatchers.<Class<InboundMessage>>any())
+        ).thenReturn(inboundMessage);
+
+        when(xPathService.getNodeValue(any(), eq(ACTION_PATH))).thenReturn(interactionId);
+        when(xPathService.getNodeValue(any(), eq(CONVERSATION_ID_PATH))).thenReturn(CONVERSATION_ID);
+
+        when(inboundMessage.getPayload()).thenReturn(payload);
+    }
+
+    private EhrExtractStatus readEhrExtractStatusFromDb() {
+        return ehrExtractStatusRepository.findByConversationId(CONVERSATION_ID).get();
+    }
+}

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/InboundMessageHandlingTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/InboundMessageHandlingTest.java
@@ -78,16 +78,12 @@ public class InboundMessageHandlingTest {
     @Test
     @SneakyThrows
     public void When_MessageProcessingFails_Expect_WholeProcessToBeFailed() {
-        // ARRANGE
         mockInboundMessage("unsupportedInteractionId", CONTINUE_MESSAGE_PAYLOAD);
-
         var ehrExtractStatus = EhrExtractStatusTestUtils.prepareEhrExtractStatus();
         ehrExtractStatusRepository.save(ehrExtractStatus);
 
-        // ACT
         inboundMessageConsumer.receive(message);
 
-        // ASSERT
         verify(message).acknowledge();
         assertThatSendNackTaskHasBeenTriggered();
         assertConversationIsFailed(ehrExtractStatus);
@@ -96,7 +92,6 @@ public class InboundMessageHandlingTest {
     @Test
     @SneakyThrows
     public void When_ProcessIsAlreadyFailed_Expect_MessageProcessingToBeAborted() {
-        // ARRANGE
         mockInboundMessage(CONTINUE_INTERACTION_ID, CONTINUE_MESSAGE_PAYLOAD);
 
         var ehrExtractStatus = EhrExtractStatusTestUtils.prepareEhrExtractStatus();
@@ -105,10 +100,8 @@ public class InboundMessageHandlingTest {
 
         var initialDbExtract = readEhrExtractStatusFromDb();
 
-        // ACT
         inboundMessageConsumer.receive(message);
 
-        // ASSERT
         verify(message).acknowledge();
         verifyNoInteractions(taskDispatcher);
 
@@ -119,17 +112,14 @@ public class InboundMessageHandlingTest {
     @Test
     @SneakyThrows
     public void When_ProcessIsNotFailed_Expect_MessageToBeProcessed() {
-        // ARRANGE
         mockInboundMessage(CONTINUE_INTERACTION_ID, CONTINUE_MESSAGE_PAYLOAD);
         ehrExtractStatusRepository.save(EhrExtractStatusTestUtils.prepareEhrExtractStatus());
 
         var initialDbExtract = readEhrExtractStatusFromDb();
         assertThat(initialDbExtract.getEhrContinue()).isNull();
 
-        // ACT
         inboundMessageConsumer.receive(message);
 
-        // ASSERT
         verify(message).acknowledge();
         assertSendDocumentTaskHasBeenTriggered();
 


### PR DESCRIPTION
These tests are focused on handling inbound messages and their purpose is to verify such things as acknowledging queue message, (the fact of) processing the message and failing the process/conversation.