### PR TITLE
NIAD-1583: Unrecognised encounter codes should display the original term text

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
@@ -37,7 +37,7 @@ import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
 @Slf4j
 public class EncounterMapper {
     private static final Mustache ENCOUNTER_STATEMENT_TO_EHR_COMPOSITION_TEMPLATE =
-            TemplateUtils.loadTemplate("ehr_encounter_to_ehr_composition_template.mustache");
+        TemplateUtils.loadTemplate("ehr_encounter_to_ehr_composition_template.mustache");
     private static final String COMPLETE_CODE = "COMPLETE";
     private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
     private static final String CONSULTATION_LIST_CODE = "325851000000107";
@@ -56,36 +56,36 @@ public class EncounterMapper {
         AgentDirectory agentDirectory = messageContext.getAgentDirectory();
 
         var encounterStatementTemplateParameters = EncounterTemplateParameters.builder()
-                .encounterStatementId(idMapper.getOrNew(ResourceType.Encounter, encounter.getIdElement()))
-                .effectiveTime(StatementTimeMappingUtils.prepareEffectiveTimeForEncounter(encounter))
-                .availabilityTime(StatementTimeMappingUtils.prepareAvailabilityTime(encounter.getPeriod().getStartElement()))
-                .status(COMPLETE_CODE)
-                .components(components)
-                .code(buildCode(encounter))
-                .displayName(buildDisplayName(encounter))
-                .originalText(buildOriginalText(encounter));
+            .encounterStatementId(idMapper.getOrNew(ResourceType.Encounter, encounter.getIdElement()))
+            .effectiveTime(StatementTimeMappingUtils.prepareEffectiveTimeForEncounter(encounter))
+            .availabilityTime(StatementTimeMappingUtils.prepareAvailabilityTime(encounter.getPeriod().getStartElement()))
+            .status(COMPLETE_CODE)
+            .components(components)
+            .code(buildCode(encounter))
+            .displayName(buildDisplayName(encounter))
+            .originalText(buildOriginalText(encounter));
 
         final String recReference = findParticipantWithCoding(encounter, ParticipantCoding.RECORDER)
-                .map(agentDirectory::getAgentId)
-                .orElseThrow(() -> new EhrMapperException("Encounter.participant recorder is required"));
+            .map(agentDirectory::getAgentId)
+            .orElseThrow(() -> new EhrMapperException("Encounter.participant recorder is required"));
         encounterStatementTemplateParameters.author(recReference);
 
         messageContext.getInputBundleHolder()
-                .getListReferencedToEncounter(encounter.getIdElement(), CONSULTATION_LIST_CODE)
-                .filter(ListResource::hasDate)
-                .map(ListResource::getDateElement)
-                .map(DateFormatUtil::toHl7Format)
-                .ifPresent(encounterStatementTemplateParameters::authorTime);
+            .getListReferencedToEncounter(encounter.getIdElement(), CONSULTATION_LIST_CODE)
+            .filter(ListResource::hasDate)
+            .map(ListResource::getDateElement)
+            .map(DateFormatUtil::toHl7Format)
+            .ifPresent(encounterStatementTemplateParameters::authorTime);
 
         final Optional<String> pprfReference = findParticipantWithCoding(encounter, ParticipantCoding.PERFORMER)
-                .map(agentDirectory::getAgentId);
+            .map(agentDirectory::getAgentId);
 
         encounterStatementTemplateParameters.participant2(pprfReference.orElse(recReference));
 
         updateEhrFolderEffectiveTime(encounter);
 
         return TemplateUtils.fillTemplate(ENCOUNTER_STATEMENT_TO_EHR_COMPOSITION_TEMPLATE,
-                encounterStatementTemplateParameters.build());
+            encounterStatementTemplateParameters.build());
     }
 
     private void updateEhrFolderEffectiveTime(Encounter encounter) {
@@ -96,39 +96,39 @@ public class EncounterMapper {
 
     private Optional<Reference> findParticipantWithCoding(Encounter encounter, ParticipantCoding coding) {
         return encounter.getParticipant().stream()
-                .filter(EncounterParticipantComponent::hasType)
-                .filter(participant -> participant.getType().stream()
-                        .filter(CodeableConcept::hasCoding)
-                        .anyMatch(codeableConcept -> codeableConcept.getCoding().stream()
-                                .filter(Coding::hasCode)
-                                .map(Coding::getCode)
-                                .anyMatch(coding.getCoding()::equals)))
-                .filter(EncounterParticipantComponent::hasIndividual)
-                .map(EncounterParticipantComponent::getIndividual)
-                .filter(Reference::hasReference)
-                .findAny();
+            .filter(EncounterParticipantComponent::hasType)
+            .filter(participant -> participant.getType().stream()
+                .filter(CodeableConcept::hasCoding)
+                .anyMatch(codeableConcept -> codeableConcept.getCoding().stream()
+                    .filter(Coding::hasCode)
+                    .map(Coding::getCode)
+                    .anyMatch(coding.getCoding()::equals)))
+            .filter(EncounterParticipantComponent::hasIndividual)
+            .map(EncounterParticipantComponent::getIndividual)
+            .filter(Reference::hasReference)
+            .findAny();
     }
 
     private boolean isSnomedAndWithinEhrCompositionVocabularyCodes(Coding coding) {
         return coding.hasSystem() && coding.getSystem().equals(SNOMED_SYSTEM)
-                && EHR_COMPOSITION_NAME_VOCABULARY_CODES.contains(coding.getCode());
+            && EHR_COMPOSITION_NAME_VOCABULARY_CODES.contains(coding.getCode());
     }
 
     private CodeableConcept extractType(Encounter encounter) {
         return encounter.getType()
-                .stream()
-                .findFirst()
-                .orElseThrow(() -> new EhrMapperException("Could not map Encounter type"));
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new EhrMapperException("Could not map Encounter type"));
     }
 
     private String buildCode(Encounter encounter) {
         var type = extractType(encounter);
         return type.getCoding()
-                .stream()
-                .filter(this::isSnomedAndWithinEhrCompositionVocabularyCodes)
-                .findFirst()
-                .map(Coding::getCode)
-                .orElse(OTHER_REPORT_CODE);
+            .stream()
+            .filter(this::isSnomedAndWithinEhrCompositionVocabularyCodes)
+            .findFirst()
+            .map(Coding::getCode)
+            .orElse(OTHER_REPORT_CODE);
     }
 
     private String buildDisplayName(Encounter encounter) {
@@ -148,22 +148,22 @@ public class EncounterMapper {
 
     @SneakyThrows
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-            justification = "https://github.com/spotbugs/spotbugs/issues/1338")
+        justification = "https://github.com/spotbugs/spotbugs/issues/1338")
     private static Set<String> getEhrCompositionNameVocabularyCodes() {
         try (InputStream is = EncounterMapper.class.getClassLoader().getResourceAsStream("ehr_composition_name_vocabulary_codes.txt");
              BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
             return reader.lines()
-                    .filter(StringUtils::isNotBlank)
-                    .collect(Collectors.toUnmodifiableSet());
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toUnmodifiableSet());
         }
     }
 
     private String getDisplayName(CodeableConcept type) {
         return type.getCoding()
-                .stream()
-                .filter(this::isSnomedAndWithinEhrCompositionVocabularyCodes)
-                .findFirst()
-                .map(Coding::getDisplay)
-                .orElse(OTHER_REPORT_DISPLAY);
+            .stream()
+            .filter(this::isSnomedAndWithinEhrCompositionVocabularyCodes)
+            .findFirst()
+            .map(Coding::getDisplay)
+            .orElse(OTHER_REPORT_DISPLAY);
     }
 }

--- a/service/src/test/resources/ehr/mapper/encounter/expected-output-encounter-10.xml
+++ b/service/src/test/resources/ehr/mapper/encounter/expected-output-encounter-10.xml
@@ -1,7 +1,9 @@
 <component typeCode="COMP">
     <ehrComposition classCode="COMPOSITION" moodCode="EVN">
         <id root="test-id" />
-        <code code="24591000000103" displayName="Other report" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"></code>
+        <code code="24591000000103" displayName="Other report" codeSystem="2.16.840.1.113883.2.1.3.2.4.15">
+            <originalText>Alert note</originalText>
+        </code>
         <statusCode code="COMPLETE" />
         <effectiveTime>
             <low value="20100113152000"/><high value="20100113162000"/>

--- a/service/src/test/resources/ehr/mapper/encounter/expected-output-encounter-8.xml
+++ b/service/src/test/resources/ehr/mapper/encounter/expected-output-encounter-8.xml
@@ -1,7 +1,9 @@
 <component typeCode="COMP">
     <ehrComposition classCode="COMPOSITION" moodCode="EVN">
         <id root="test-id" />
-        <code code="24591000000103" displayName="Other report" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"></code>
+        <code code="24591000000103" displayName="Other report" codeSystem="2.16.840.1.113883.2.1.3.2.4.15">
+            <originalText>test</originalText>
+        </code>
         <statusCode code="COMPLETE" />
         <effectiveTime>
             <low value="20100113152000"/><high value="20100113162000"/>


### PR DESCRIPTION
- In the case of unrecognised encounter code, the original text should first be provided by the .text value (If it is present) otherwise the .display value should be used (always present.)