### PR TITLE
NIAD-1719: BloodPressure: Exception when no effectivePeriod.start

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -22,8 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils.extractTextOrCoding;
-import static uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils.prepareAvailabilityTime;
-import static uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils.prepareAvailabilityTimeForObservationStatement;
+import static uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils.prepareAvailabilityTimeForObservation;
 import static uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils.prepareEffectiveTimeForObservation;
 import static uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils.loadTemplate;
 
@@ -64,7 +63,7 @@ public class BloodPressureMapper {
             .isNested(isNested)
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))
             .effectiveTime(prepareEffectiveTimeForObservation(observation))
-            .availabilityTime(prepareAvailabilityTimeForObservationStatement(observation))
+            .availabilityTime(prepareAvailabilityTimeForObservation(observation))
             .compoundStatementCode(buildBloodPressureCode(observation));
 
         extractBloodPressureComponent(observation, SYSTOLIC_CODE).ifPresent(observationComponent -> {
@@ -86,7 +85,7 @@ public class BloodPressureMapper {
         extractNarrativeText(observation).ifPresent(narrativeText -> {
             builder.narrativeId(randomIdGeneratorService.createNewId());
             builder.narrativeText(narrativeText);
-            builder.narrativeAvailabilityTime(prepareAvailabilityTimeForObservationStatement(observation));
+            builder.narrativeAvailabilityTime(prepareAvailabilityTimeForObservation(observation));
         });
 
         if (observation.hasPerformer()) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -64,7 +64,7 @@ public class BloodPressureMapper {
             .isNested(isNested)
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))
             .effectiveTime(prepareEffectiveTimeForObservation(observation))
-            .availabilityTime(prepareAvailabilityTime(observation.getIssuedElement()))
+            .availabilityTime(prepareAvailabilityTimeForObservationStatement(observation))
             .compoundStatementCode(buildBloodPressureCode(observation));
 
         extractBloodPressureComponent(observation, SYSTOLIC_CODE).ifPresent(observationComponent -> {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapper.java
@@ -54,7 +54,7 @@ public class ObservationStatementMapper {
         var observationStatementTemplateParametersBuilder = ObservationStatementTemplateParameters.builder()
             .observationStatementId(idMapper.getOrNew(ResourceType.Observation, observation.getIdElement()))
             .code(prepareCode(observation))
-            .issued(StatementTimeMappingUtils.prepareAvailabilityTimeForObservationStatement(observation))
+            .issued(StatementTimeMappingUtils.prepareAvailabilityTimeForObservation(observation))
             .isNested(isNested)
             .effectiveTime(StatementTimeMappingUtils.prepareEffectiveTimeForObservation(observation));
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -100,7 +100,7 @@ public class ObservationMapper {
         String codeElement = prepareCodeElement(observation);
         String effectiveTime = StatementTimeMappingUtils.prepareEffectiveTimeForObservation(observation);
         String availabilityTimeElement =
-            StatementTimeMappingUtils.prepareAvailabilityTimeForObservationStatement(observation);
+            StatementTimeMappingUtils.prepareAvailabilityTimeForObservation(observation);
         CompoundStatementClassCode classCode = prepareClassCode(relatedObservations);
 
         String observationStatement = prepareObservationStatement(observationAssociatedWithSpecimen, classCode)
@@ -165,7 +165,7 @@ public class ObservationMapper {
             .observationStatementId(holder.nextHl7InstanceIdentifier())
             .codeElement(prepareCodeElement(holder.getObservation()))
             .effectiveTime(StatementTimeMappingUtils.prepareEffectiveTimeForObservation(holder.getObservation()))
-            .availabilityTimeElement(StatementTimeMappingUtils.prepareAvailabilityTimeForObservationStatement(holder.getObservation()));
+            .availabilityTimeElement(StatementTimeMappingUtils.prepareAvailabilityTimeForObservation(holder.getObservation()));
 
         if (holder.getObservation().hasValue()) {
             Type value = holder.getObservation().getValue();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
@@ -63,7 +63,7 @@ public final class StatementTimeMappingUtils {
         return DEFAULT_AVAILABILITY_TIME_VALUE;
     }
 
-    public static String prepareAvailabilityTimeForObservationStatement(Observation observation) {
+    public static String prepareAvailabilityTimeForObservation(Observation observation) {
         if (observation.hasEffectiveDateTimeType() && observation.getEffectiveDateTimeType().hasValue()) {
             return String.format(
                 AVAILABILITY_TIME_VALUE_TEMPLATE,

--- a/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-data.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-data.xml
@@ -6,7 +6,7 @@
         <effectiveTime>
             <center value="20121008104149"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20121008104149"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -15,7 +15,7 @@
                 <effectiveTime>
                     <center value="20121008104149"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20121008104149"/>
                 <value xsi:type="PQ" value="120" unit="1"><translation value="120"><originalText>mmHg</originalText></translation></value>
                 <referenceRange typeCode="REFV">
     <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">
@@ -34,7 +34,7 @@
                 <effectiveTime>
                     <center value="20121008104149"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20121008104149"/>
                 <value xsi:type="PQ" value="75" unit="1"><translation value="75"><originalText>mmHg</originalText></translation></value>
                 <referenceRange typeCode="REFV">
     <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">

--- a/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-diastolic-data-only.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-diastolic-data-only.xml
@@ -6,7 +6,7 @@
         <effectiveTime>
             <center value="20121008104149"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20121008104149"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -15,7 +15,7 @@
                 <effectiveTime>
                     <center value="20121008104149"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20121008104149"/>
                 <value xsi:type="PQ" value="75" unit="1"><translation value="75"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-period-date.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-period-date.xml
@@ -6,7 +6,7 @@
         <effectiveTime>
             <low value="20100113"/><high value="20100115"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20100113"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -15,7 +15,7 @@
                 <effectiveTime>
                     <low value="20100113"/><high value="20100115"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20100113"/>
                 <value xsi:type="PQ" value="120" unit="1"><translation value="120"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -27,7 +27,7 @@
                 <effectiveTime>
                     <low value="20100113"/><high value="20100115"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20100113"/>
                 <value xsi:type="PQ" value="75" unit="1"><translation value="75"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-systolic-data-only.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-with-systolic-data-only.xml
@@ -6,7 +6,7 @@
         <effectiveTime>
             <center value="20121008104149"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20121008104149"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -15,7 +15,7 @@
                 <effectiveTime>
                     <center value="20121008104149"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20121008104149"/>
                 <value xsi:type="PQ" value="120" unit="1"><translation value="120"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-without-data.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-without-data.xml
@@ -6,7 +6,7 @@
         <effectiveTime>
             <center value="20060818"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060818"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -15,7 +15,7 @@
                 <effectiveTime>
                     <center value="20060818"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060818"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -26,7 +26,7 @@
                 <effectiveTime>
                     <center value="20060818"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060818"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">

--- a/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-without-effective-date.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/arterial-pressure-without-effective-date.xml
@@ -6,7 +6,7 @@
         <effectiveTime>
             <center nullFlavor="UNK"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime nullFlavor="UNK"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -15,7 +15,7 @@
                 <effectiveTime>
                     <center nullFlavor="UNK"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime nullFlavor="UNK"/>
                 <value xsi:type="PQ" value="120" unit="1"><translation value="120"><originalText>mmHg</originalText></translation></value>
                 <referenceRange typeCode="REFV">
     <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">
@@ -34,7 +34,7 @@
                 <effectiveTime>
                     <center nullFlavor="UNK"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime nullFlavor="UNK"/>
                 <value xsi:type="PQ" value="75" unit="1"><translation value="75"><originalText>mmHg</originalText></translation></value>
                 <referenceRange typeCode="REFV">
     <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-codeable-concepts.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-codeable-concepts.xml
@@ -7,7 +7,7 @@
         <effectiveTime>
             <center value="20121008104149"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20121008104149"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
@@ -18,7 +18,7 @@
                 <effectiveTime>
                     <center value="20121008104149"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20121008104149"/>
                 <value xsi:type="PQ" value="120" unit="1"><translation value="120"><originalText>mmHg</originalText></translation></value>
                 <referenceRange typeCode="REFV">
     <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">
@@ -39,7 +39,7 @@
                 <effectiveTime>
                     <center value="20121008104149"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20121008104149"/>
                 <value xsi:type="PQ" value="75" unit="1"><translation value="75"><originalText>mmHg</originalText></translation></value>
                 <referenceRange typeCode="REFV">
     <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">

--- a/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
@@ -598,7 +598,7 @@ The line below contains special characters...
         <effectiveTime>
             <center value="20100714175500"/>
         </effectiveTime>
-        <availabilityTime value="20100714162813"/>
+        <availabilityTime value="20100714175500"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="test-id-3"/>
@@ -607,7 +607,7 @@ The line below contains special characters...
                 <effectiveTime>
                     <center value="20100714175500"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162813"/>
+                <availabilityTime value="20100714175500"/>
                 <value xsi:type="PQ" value="120" unit="1"><translation value="120"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -619,7 +619,7 @@ The line below contains special characters...
                 <effectiveTime>
                     <center value="20100714175500"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162813"/>
+                <availabilityTime value="20100714175500"/>
                 <value xsi:type="PQ" value="75" unit="1"><translation value="75"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -7816,9 +7816,9 @@ The line below contains special characters...
         <effectiveTime>
             <center value="20100714"/>
         </effectiveTime>
-        <availabilityTime value="20100714162749"/>
+        <availabilityTime value="20100714"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20100714162749" />
+            <time value="20100714" />
             <agentRef classCode="AGNT">
                 <id root="test-id-3" />
             </agentRef>
@@ -7836,7 +7836,7 @@ The line below contains special characters...
         <effectiveTime>
             <center value="20100714"/>
         </effectiveTime>
-        <availabilityTime value="20100714162749"/>
+        <availabilityTime value="20100714"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="test-id-3"/>
@@ -7845,7 +7845,7 @@ The line below contains special characters...
                 <effectiveTime>
                     <center value="20100714"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162749"/>
+                <availabilityTime value="20100714"/>
                 <value xsi:type="PQ" value="134" unit="1"><translation value="134"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -7857,7 +7857,7 @@ The line below contains special characters...
                 <effectiveTime>
                     <center value="20100714"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162749"/>
+                <availabilityTime value="20100714"/>
                 <value xsi:type="PQ" value="90" unit="1"><translation value="90"><originalText>mmHg</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC4/9465699926_Sajal_full_20210122.xml
+++ b/service/src/test/resources/uat/output/TC4/9465699926_Sajal_full_20210122.xml
@@ -2999,7 +2999,7 @@ Status: unknown</text>
         <effectiveTime>
             <center value="20110307162500"/>
         </effectiveTime>
-        <availabilityTime value="20110922110028"/>
+        <availabilityTime value="20110307162500"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="452AFD1A-B615-4E2C-A733-544A3426DA24"/>
@@ -3009,7 +3009,7 @@ Status: unknown</text>
                 <effectiveTime>
                     <center value="20110307162500"/>
                 </effectiveTime>
-                <availabilityTime value="20110922110028"/>
+                <availabilityTime value="20110307162500"/>
                 <value xsi:type="PQ" value="130.000" unit="1"><translation value="130.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3022,7 +3022,7 @@ Status: unknown</text>
                 <effectiveTime>
                     <center value="20110307162500"/>
                 </effectiveTime>
-                <availabilityTime value="20110922110028"/>
+                <availabilityTime value="20110307162500"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3167,7 +3167,7 @@ Status: unknown</text>
         <effectiveTime>
             <center value="20110307164600"/>
         </effectiveTime>
-        <availabilityTime value="20110922110028"/>
+        <availabilityTime value="20110307164600"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="67DE330E-EDFA-462F-8732-1E91E6DAED9C"/>
@@ -3177,7 +3177,7 @@ Status: unknown</text>
                 <effectiveTime>
                     <center value="20110307164600"/>
                 </effectiveTime>
-                <availabilityTime value="20110922110028"/>
+                <availabilityTime value="20110307164600"/>
                 <value xsi:type="PQ" value="125.000" unit="1"><translation value="125.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3190,7 +3190,7 @@ Status: unknown</text>
                 <effectiveTime>
                     <center value="20110307164600"/>
                 </effectiveTime>
-                <availabilityTime value="20110922110028"/>
+                <availabilityTime value="20110307164600"/>
                 <value xsi:type="PQ" value="70.000" unit="1"><translation value="70.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC4/9465700339_Yamura_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4/9465700339_Yamura_full_20210119.xml
@@ -438,7 +438,7 @@
         <effectiveTime>
             <center value="20050201113300"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20050201113300"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="10B9023B-A997-4449-AF63-EF3015E4C7B5"/>
@@ -448,7 +448,7 @@
                 <effectiveTime>
                     <center value="20050201113300"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20050201113300"/>
                 <value xsi:type="PQ" value="180.000" unit="1"><translation value="180.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -461,7 +461,7 @@
                 <effectiveTime>
                     <center value="20050201113300"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20050201113300"/>
                 <value xsi:type="PQ" value="60.000" unit="1"><translation value="60.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -2686,7 +2686,7 @@ Abnormal</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="7374E13A-D408-460C-A021-3441347C5027"/>
@@ -2696,7 +2696,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="182.000" unit="1"><translation value="182.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -2709,7 +2709,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="92.000" unit="1"><translation value="92.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5151,9 +5151,9 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20131118094149" />
+            <time value="20060425122200" />
             <agentRef classCode="AGNT">
                 <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34" />
             </agentRef>
@@ -5172,7 +5172,7 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="56B35114-6813-469B-AD36-F9E4944E7866"/>
@@ -5182,7 +5182,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="181.000" unit="1"><translation value="181.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5195,7 +5195,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -5223,9 +5223,9 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20131118094149" />
+            <time value="20060425122200" />
             <agentRef classCode="AGNT">
                 <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34" />
             </agentRef>
@@ -5244,7 +5244,7 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="A7C55C1F-89CB-4D88-BD1C-F7E520B44A02"/>
@@ -5254,7 +5254,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -5266,7 +5266,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="91.000" unit="1"><translation value="91.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5295,9 +5295,9 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425163000"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425163000"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20131118094149" />
+            <time value="20060425163000" />
             <agentRef classCode="AGNT">
                 <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34" />
             </agentRef>
@@ -5316,7 +5316,7 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425163000"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425163000"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="CD0DE06B-A109-4037-AC72-9E83D2327E6E"/>
@@ -5326,7 +5326,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
                 <value xsi:type="PQ" value="180.000" unit="1"><translation value="180.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5339,7 +5339,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -5367,9 +5367,9 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425163000"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425163000"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20131118094149" />
+            <time value="20060425163000" />
             <agentRef classCode="AGNT">
                 <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34" />
             </agentRef>
@@ -5388,7 +5388,7 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425163000"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425163000"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="86E89638-765F-422C-9B96-A091F617FBB0"/>
@@ -5398,7 +5398,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -5410,7 +5410,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC4/9465701297_Livermore_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4/9465701297_Livermore_full_20210119.xml
@@ -411,7 +411,7 @@
         <effectiveTime>
             <center value="20200904"/>
         </effectiveTime>
-        <availabilityTime value="20200904134806"/>
+        <availabilityTime value="20200904"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3316531F-5705-424C-9E1A-EE694FB411B4"/>
@@ -421,7 +421,7 @@
                 <effectiveTime>
                     <center value="20200904"/>
                 </effectiveTime>
-                <availabilityTime value="20200904134806"/>
+                <availabilityTime value="20200904"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -434,7 +434,7 @@
                 <effectiveTime>
                     <center value="20200904"/>
                 </effectiveTime>
-                <availabilityTime value="20200904134806"/>
+                <availabilityTime value="20200904"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -627,7 +627,7 @@
         <effectiveTime>
             <center value="20200907174500"/>
         </effectiveTime>
-        <availabilityTime value="20201105134936"/>
+        <availabilityTime value="20200907174500"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="8DF92722-5B5F-4324-866E-0328D5EA4286"/>
@@ -637,7 +637,7 @@
                 <effectiveTime>
                     <center value="20200907174500"/>
                 </effectiveTime>
-                <availabilityTime value="20201105134936"/>
+                <availabilityTime value="20200907174500"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -650,7 +650,7 @@
                 <effectiveTime>
                     <center value="20200907174500"/>
                 </effectiveTime>
-                <availabilityTime value="20201105134936"/>
+                <availabilityTime value="20200907174500"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1127,7 +1127,7 @@
         <effectiveTime>
             <center value="20201110115000"/>
         </effectiveTime>
-        <availabilityTime value="20201110115343"/>
+        <availabilityTime value="20201110115000"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="CF670325-7982-46BA-9A52-85C3C78FE40A"/>
@@ -1137,7 +1137,7 @@
                 <effectiveTime>
                     <center value="20201110115000"/>
                 </effectiveTime>
-                <availabilityTime value="20201110115343"/>
+                <availabilityTime value="20201110115000"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1150,7 +1150,7 @@
                 <effectiveTime>
                     <center value="20201110115000"/>
                 </effectiveTime>
-                <availabilityTime value="20201110115343"/>
+                <availabilityTime value="20201110115000"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1615,7 +1615,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125756"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3794F0FE-ECA1-4F8C-A321-598FBD1B568C"/>
@@ -1625,7 +1625,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125756"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1638,7 +1638,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125756"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1658,7 +1658,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125757"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="681FEBF5-6290-4AA0-927C-B1047AE8D21D"/>
@@ -1668,7 +1668,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="100.000" unit="1"><translation value="100.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1681,7 +1681,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1708,7 +1708,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125757"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3A3B1B6F-7DC5-4BE3-A496-0BC243583EBA"/>
@@ -1718,7 +1718,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1730,7 +1730,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1784,7 +1784,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="7AC9EB04-E71D-4E6A-BCCD-3A4A445D91F7"/>
@@ -1794,7 +1794,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1807,7 +1807,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1833,7 +1833,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="C34945D5-A784-4742-85EC-7E98AC6AA19C"/>
@@ -1843,7 +1843,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1855,7 +1855,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1883,7 +1883,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="C3375CCA-1E80-4F29-AAC1-5D8D27ED605F"/>
@@ -1893,7 +1893,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="130.000" unit="1"><translation value="130.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1906,7 +1906,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1933,7 +1933,7 @@
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34"/>
@@ -1943,7 +1943,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1955,7 +1955,7 @@
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="100.000" unit="1"><translation value="100.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -4531,9 +4531,9 @@
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217130131"/>
+        <availabilityTime value="20201217"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20201217130131" />
+            <time value="20201217" />
             <agentRef classCode="AGNT">
                 <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8" />
             </agentRef>
@@ -4552,7 +4552,7 @@
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217130131"/>
+        <availabilityTime value="20201217"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="E24CCAB7-FF1A-4F00-B125-D383D2BA80A1"/>
@@ -4562,7 +4562,7 @@
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217130131"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="127.000" unit="1"><translation value="127.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -4575,7 +4575,7 @@
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217130131"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="98.000" unit="1"><translation value="98.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -4596,9 +4596,9 @@
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125908"/>
+        <availabilityTime value="20201217"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20201217125908" />
+            <time value="20201217" />
             <agentRef classCode="AGNT">
                 <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8" />
             </agentRef>
@@ -4618,7 +4618,7 @@
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125908"/>
+        <availabilityTime value="20201217"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="0814FE49-058E-4B3C-9F74-040922A26099"/>
@@ -4628,7 +4628,7 @@
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125908"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="132.000" unit="1"><translation value="132.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -4641,7 +4641,7 @@
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125908"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="95.000" unit="1"><translation value="95.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -4662,9 +4662,9 @@
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125844"/>
+        <availabilityTime value="20201217"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20201217125844" />
+            <time value="20201217" />
             <agentRef classCode="AGNT">
                 <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8" />
             </agentRef>
@@ -4684,7 +4684,7 @@
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125844"/>
+        <availabilityTime value="20201217"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="CBA50EF5-9180-40A3-B8FA-161B6E15892A"/>
@@ -4694,7 +4694,7 @@
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125844"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="121.000" unit="1"><translation value="121.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -4707,7 +4707,7 @@
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125844"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="101.000" unit="1"><translation value="101.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC4/9465701483_Dougill_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4/9465701483_Dougill_full_20210119.xml
@@ -2685,7 +2685,7 @@
         <effectiveTime>
             <center value="20110111153300"/>
         </effectiveTime>
-        <availabilityTime value="20110111153927"/>
+        <availabilityTime value="20110111153300"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="BB8DEB7C-BE1B-4639-8213-D94E8FEFA0F6"/>
@@ -2696,7 +2696,7 @@
                 <effectiveTime>
                     <center value="20110111153300"/>
                 </effectiveTime>
-                <availabilityTime value="20110111153927"/>
+                <availabilityTime value="20110111153300"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -2710,7 +2710,7 @@
                 <effectiveTime>
                     <center value="20110111153300"/>
                 </effectiveTime>
-                <availabilityTime value="20110111153927"/>
+                <availabilityTime value="20110111153300"/>
                 <value xsi:type="PQ" value="50.000" unit="1"><translation value="50.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC4/9465701483_Nel_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4/9465701483_Nel_full_20210119.xml
@@ -2685,7 +2685,7 @@
         <effectiveTime>
             <center value="20110111153300"/>
         </effectiveTime>
-        <availabilityTime value="20110111153927"/>
+        <availabilityTime value="20110111153300"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="BB8DEB7C-BE1B-4639-8213-D94E8FEFA0F6"/>
@@ -2696,7 +2696,7 @@
                 <effectiveTime>
                     <center value="20110111153300"/>
                 </effectiveTime>
-                <availabilityTime value="20110111153927"/>
+                <availabilityTime value="20110111153300"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -2710,7 +2710,7 @@
                 <effectiveTime>
                     <center value="20110111153300"/>
                 </effectiveTime>
-                <availabilityTime value="20110111153927"/>
+                <availabilityTime value="20110111153300"/>
                 <value xsi:type="PQ" value="50.000" unit="1"><translation value="50.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC7/9465700339_Yamura_full_20210602.xml
+++ b/service/src/test/resources/uat/output/TC7/9465700339_Yamura_full_20210602.xml
@@ -539,7 +539,7 @@ Line breaks in the notes</text>
         <effectiveTime>
             <center value="20050201113300"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20050201113300"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="FE85DB22-274E-4B1D-9698-5C4809E9CD42"/>
@@ -549,7 +549,7 @@ Line breaks in the notes</text>
                 <effectiveTime>
                     <center value="20050201113300"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20050201113300"/>
                 <value xsi:type="PQ" value="180.000" unit="1"><translation value="180.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -562,7 +562,7 @@ Line breaks in the notes</text>
                 <effectiveTime>
                     <center value="20050201113300"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20050201113300"/>
                 <value xsi:type="PQ" value="60.000" unit="1"><translation value="60.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3147,7 +3147,7 @@ Abnormal</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="4255C920-68D4-46F4-B261-8F2C8D80D3AF"/>
@@ -3157,7 +3157,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -3169,7 +3169,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="91.000" unit="1"><translation value="91.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3196,7 +3196,7 @@ Abnormal</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="D27E4A12-8EA6-44D7-AB94-821503546B45"/>
@@ -3206,7 +3206,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="181.000" unit="1"><translation value="181.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3219,7 +3219,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -3245,7 +3245,7 @@ Abnormal</text>
         <effectiveTime>
             <center value="20060425122200"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425122200"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="2DAE1ADC-4B4F-4081-84C4-E93E78346185"/>
@@ -3255,7 +3255,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="182.000" unit="1"><translation value="182.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3268,7 +3268,7 @@ Abnormal</text>
                 <effectiveTime>
                     <center value="20060425122200"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425122200"/>
                 <value xsi:type="PQ" value="92.000" unit="1"><translation value="92.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3334,7 +3334,7 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425163000"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425163000"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3D83E26F-FCA2-49F8-BC3D-6F0B8BB33C05"/>
@@ -3344,7 +3344,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -3356,7 +3356,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3383,7 +3383,7 @@ and extending onto other lines as well.</text>
         <effectiveTime>
             <center value="20060425163000"/>
         </effectiveTime>
-        <availabilityTime value="20131118094149"/>
+        <availabilityTime value="20060425163000"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="49C185EE-784C-497C-A7E0-C63A25C057B7"/>
@@ -3393,7 +3393,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
                 <value xsi:type="PQ" value="180.000" unit="1"><translation value="180.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -3406,7 +3406,7 @@ and extending onto other lines as well.</text>
                 <effectiveTime>
                     <center value="20060425163000"/>
                 </effectiveTime>
-                <availabilityTime value="20131118094149"/>
+                <availabilityTime value="20060425163000"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">

--- a/service/src/test/resources/uat/output/TC7/9465701297_Livermore_full_20210602.xml
+++ b/service/src/test/resources/uat/output/TC7/9465701297_Livermore_full_20210602.xml
@@ -412,7 +412,7 @@
         <effectiveTime>
             <center value="20200904"/>
         </effectiveTime>
-        <availabilityTime value="20200904134806"/>
+        <availabilityTime value="20200904"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3316531F-5705-424C-9E1A-EE694FB411B4"/>
@@ -422,7 +422,7 @@
                 <effectiveTime>
                     <center value="20200904"/>
                 </effectiveTime>
-                <availabilityTime value="20200904134806"/>
+                <availabilityTime value="20200904"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -435,7 +435,7 @@
                 <effectiveTime>
                     <center value="20200904"/>
                 </effectiveTime>
-                <availabilityTime value="20200904134806"/>
+                <availabilityTime value="20200904"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -628,7 +628,7 @@
         <effectiveTime>
             <center value="20200907174500"/>
         </effectiveTime>
-        <availabilityTime value="20201105134936"/>
+        <availabilityTime value="20200907174500"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="8DF92722-5B5F-4324-866E-0328D5EA4286"/>
@@ -638,7 +638,7 @@
                 <effectiveTime>
                     <center value="20200907174500"/>
                 </effectiveTime>
-                <availabilityTime value="20201105134936"/>
+                <availabilityTime value="20200907174500"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -651,7 +651,7 @@
                 <effectiveTime>
                     <center value="20200907174500"/>
                 </effectiveTime>
-                <availabilityTime value="20201105134936"/>
+                <availabilityTime value="20200907174500"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1131,7 +1131,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201110115000"/>
         </effectiveTime>
-        <availabilityTime value="20201110115343"/>
+        <availabilityTime value="20201110115000"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="CF670325-7982-46BA-9A52-85C3C78FE40A"/>
@@ -1141,7 +1141,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201110115000"/>
                 </effectiveTime>
-                <availabilityTime value="20201110115343"/>
+                <availabilityTime value="20201110115000"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1154,7 +1154,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201110115000"/>
                 </effectiveTime>
-                <availabilityTime value="20201110115343"/>
+                <availabilityTime value="20201110115000"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1621,7 +1621,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125756"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3794F0FE-ECA1-4F8C-A321-598FBD1B568C"/>
@@ -1631,7 +1631,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125756"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1644,7 +1644,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125756"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1664,7 +1664,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125757"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="681FEBF5-6290-4AA0-927C-B1047AE8D21D"/>
@@ -1674,7 +1674,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="100.000" unit="1"><translation value="100.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1687,7 +1687,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1714,7 +1714,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125757"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="3A3B1B6F-7DC5-4BE3-A496-0BC243583EBA"/>
@@ -1724,7 +1724,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1736,7 +1736,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125757"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1790,7 +1790,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="7AC9EB04-E71D-4E6A-BCCD-3A4A445D91F7"/>
@@ -1800,7 +1800,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1813,7 +1813,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1839,7 +1839,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="C34945D5-A784-4742-85EC-7E98AC6AA19C"/>
@@ -1849,7 +1849,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1861,7 +1861,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1889,7 +1889,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="C3375CCA-1E80-4F29-AAC1-5D8D27ED605F"/>
@@ -1899,7 +1899,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="130.000" unit="1"><translation value="130.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -1912,7 +1912,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1939,7 +1939,7 @@ Episodicity : Review</text>
         <effectiveTime>
             <center value="20201217124900"/>
         </effectiveTime>
-        <availabilityTime value="20201217125758"/>
+        <availabilityTime value="20201217124900"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="A9BEB770-CF96-44BD-ABFC-609E8643FB34"/>
@@ -1949,7 +1949,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
             </ObservationStatement>
         </component>
         <component typeCode="COMP" contextConductionInd="true">
@@ -1961,7 +1961,7 @@ Episodicity : Review</text>
                 <effectiveTime>
                     <center value="20201217124900"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125758"/>
+                <availabilityTime value="20201217124900"/>
                 <value xsi:type="PQ" value="100.000" unit="1"><translation value="100.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5062,9 +5062,9 @@ Episodicity : First
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217130131"/>
+        <availabilityTime value="20201217"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20201217130131" />
+            <time value="20201217" />
             <agentRef classCode="AGNT">
                 <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8" />
             </agentRef>
@@ -5083,7 +5083,7 @@ Episodicity : First
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217130131"/>
+        <availabilityTime value="20201217"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="19B160E4-9406-4642-B202-4BDCF073BE76"/>
@@ -5093,7 +5093,7 @@ Episodicity : First
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217130131"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="127.000" unit="1"><translation value="127.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5106,7 +5106,7 @@ Episodicity : First
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217130131"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="98.000" unit="1"><translation value="98.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5127,9 +5127,9 @@ Episodicity : First
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125908"/>
+        <availabilityTime value="20201217"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20201217125908" />
+            <time value="20201217" />
             <agentRef classCode="AGNT">
                 <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8" />
             </agentRef>
@@ -5149,7 +5149,7 @@ Episodicity : First
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125908"/>
+        <availabilityTime value="20201217"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="7217C8E7-F51A-46B4-8590-6FF88478C7A8"/>
@@ -5159,7 +5159,7 @@ Episodicity : First
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125908"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="132.000" unit="1"><translation value="132.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5172,7 +5172,7 @@ Episodicity : First
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125908"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="95.000" unit="1"><translation value="95.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5193,9 +5193,9 @@ Episodicity : First
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125844"/>
+        <availabilityTime value="20201217"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20201217125844" />
+            <time value="20201217" />
             <agentRef classCode="AGNT">
                 <id root="1AB77AC2-0026-4C4B-A168-DAA15D108BA8" />
             </agentRef>
@@ -5215,7 +5215,7 @@ Episodicity : First
         <effectiveTime>
             <center value="20201217"/>
         </effectiveTime>
-        <availabilityTime value="20201217125844"/>
+        <availabilityTime value="20201217"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="2EC20A11-7A24-4442-B0D8-051C30A02BD2"/>
@@ -5225,7 +5225,7 @@ Episodicity : First
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125844"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="121.000" unit="1"><translation value="121.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -5238,7 +5238,7 @@ Episodicity : First
                 <effectiveTime>
                     <center value="20201217"/>
                 </effectiveTime>
-                <availabilityTime value="20201217125844"/>
+                <availabilityTime value="20201217"/>
                 <value xsi:type="PQ" value="101.000" unit="1"><translation value="101.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC7/9465701459_Nel_full_20210602.xml
+++ b/service/src/test/resources/uat/output/TC7/9465701459_Nel_full_20210602.xml
@@ -584,7 +584,7 @@ note - this is obviously wrong?</text>
         <effectiveTime>
             <center value="20100714175500"/>
         </effectiveTime>
-        <availabilityTime value="20100714162813"/>
+        <availabilityTime value="20100714175500"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="25DBE266-2210-41D4-ADB0-C033F3EBED99"/>
@@ -595,7 +595,7 @@ note - this is obviously wrong?</text>
                 <effectiveTime>
                     <center value="20100714175500"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162813"/>
+                <availabilityTime value="20100714175500"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -609,7 +609,7 @@ note - this is obviously wrong?</text>
                 <effectiveTime>
                     <center value="20100714175500"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162813"/>
+                <availabilityTime value="20100714175500"/>
                 <value xsi:type="PQ" value="75.000" unit="1"><translation value="75.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -7708,9 +7708,9 @@ This is a standalone note with extended chars Ñ§¬ Problem Info: Problem Notes
         <effectiveTime>
             <center value="20100714"/>
         </effectiveTime>
-        <availabilityTime value="20100714162749"/>
+        <availabilityTime value="20100714"/>
         <author typeCode="AUT" contextControlCode="OP">
-            <time value="20100714162749" />
+            <time value="20100714" />
             <agentRef classCode="AGNT">
                 <id root="2D70F602-6BB1-47E0-B2EC-39912A59787D" />
             </agentRef>
@@ -7729,7 +7729,7 @@ This is a standalone note with extended chars Ñ§¬ Problem Info: Problem Notes
         <effectiveTime>
             <center value="20100714"/>
         </effectiveTime>
-        <availabilityTime value="20100714162749"/>
+        <availabilityTime value="20100714"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="74FFD762-0391-492E-94FC-9B825E906898"/>
@@ -7740,7 +7740,7 @@ This is a standalone note with extended chars Ñ§¬ Problem Info: Problem Notes
                 <effectiveTime>
                     <center value="20100714"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162749"/>
+                <availabilityTime value="20100714"/>
                 <value xsi:type="PQ" value="134.000" unit="1"><translation value="134.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -7754,7 +7754,7 @@ This is a standalone note with extended chars Ñ§¬ Problem Info: Problem Notes
                 <effectiveTime>
                     <center value="20100714"/>
                 </effectiveTime>
-                <availabilityTime value="20100714162749"/>
+                <availabilityTime value="20100714"/>
                 <value xsi:type="PQ" value="90.000" unit="1"><translation value="90.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>

--- a/service/src/test/resources/uat/output/TC7/9465701483_Dougill_full_20210602.xml
+++ b/service/src/test/resources/uat/output/TC7/9465701483_Dougill_full_20210602.xml
@@ -2924,7 +2924,7 @@
         <effectiveTime>
             <center value="20110111153300"/>
         </effectiveTime>
-        <availabilityTime value="20110111153927"/>
+        <availabilityTime value="20110111153300"/>
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="49259291-5B92-4C0B-BE40-C299A8B02677"/>
@@ -2935,7 +2935,7 @@
                 <effectiveTime>
                     <center value="20110111153300"/>
                 </effectiveTime>
-                <availabilityTime value="20110111153927"/>
+                <availabilityTime value="20110111153300"/>
                 <value xsi:type="PQ" value="120.000" unit="1"><translation value="120.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>
@@ -2949,7 +2949,7 @@
                 <effectiveTime>
                     <center value="20110111153300"/>
                 </effectiveTime>
-                <availabilityTime value="20110111153927"/>
+                <availabilityTime value="20110111153300"/>
                 <value xsi:type="PQ" value="50.000" unit="1"><translation value="50.000"><originalText>mm[Hg]</originalText></translation></value>
             </ObservationStatement>
         </component>


### PR DESCRIPTION
- Bug [NIAD-1719](https://gpitbjss.atlassian.net/browse/NIAD-1719)
- The ticket describes an issue around effectiveTime for BloodPressure based Observations. However this functionality was already fixed, and this PR is more focused on the availabilityTime of the BloodPressure observation. Aligning them with that of normal Observations that was brought in in [NIAD-1559](https://github.com/nhsconnect/integration-adaptor-gp2gp/pull/324)