### PR TITLE
NIAD-1759: DiagnosticReport: User comments handling in narrative statement

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -7,17 +7,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.xml.stream.events.Comment;
-
 import org.apache.commons.lang3.StringUtils;
-import org.checkerframework.checker.nullness.Opt;
 import org.hl7.fhir.dstu3.model.Attachment;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationRelatedComponent;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.Reference;
-import org.hl7.fhir.dstu3.model.ResourceType;
 import org.hl7.fhir.dstu3.model.SampledData;
 import org.hl7.fhir.dstu3.model.Type;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -235,7 +231,7 @@ public class ObservationMapper {
         if (!interpretationTextAndComment.toString().isBlank()) {
             narrativeStatementsBlock.append(
                 mapObservationToNarrativeStatement(
-                    holder, interpretationTextAndComment.toString().trim(), resolveCommentType(observation).getCode()
+                    holder, interpretationTextAndComment.toString().trim(), prepareCommentType(observation).getCode()
                 )
             );
         }
@@ -273,11 +269,10 @@ public class ObservationMapper {
         return Optional.empty();
     }
 
-    private CommentType resolveCommentType(Observation observation){
-        return observation.getRelated()
+    private CommentType prepareCommentType(Observation observation){
+        return observation.getCode().getCoding()
             .stream()
-            .map(e -> e.getTarget().getReferenceElement())
-            .anyMatch(e -> messageContext.getInputBundleHolder().getResource(e).isPresent()) ?
+            .anyMatch(coding -> COMMENT_NOTE_CODE.equals(coding.getCode())) ?
             CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -276,11 +276,9 @@ public class ObservationMapper {
     private CommentType resolveCommentType(Observation observation){
         return observation.getRelated()
             .stream()
-            .map(rel -> rel.getTarget().getResource())
-            .filter(res -> ResourceType.Observation.name().equals(res.getIdElement().getResourceType()))
-            .map(Observation.class::cast)
-            .anyMatch(e -> e.getCode().getCoding().stream().anyMatch(f -> COMMENT_NOTE_CODE.equals(f.getCode())))
-            ? CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
+            .map(e -> e.getTarget().getReferenceElement())
+            .anyMatch(e -> messageContext.getInputBundleHolder().getResource(e).isPresent()) ?
+            CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
     }
 
     private String mapObservationToNarrativeStatement(MultiStatementObservationHolder holder, String comment, String commentType) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper.diagnosticreport;
 
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.diagnosticreport.DiagnosticReportMapper.DUMMY_OBSERVATION_ID_PREFIX;
+import static uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils.hasCode;
 
 import java.util.List;
 import java.util.Optional;
@@ -270,9 +271,7 @@ public class ObservationMapper {
     }
 
     private CommentType prepareCommentType(Observation observation) {
-        return observation.getCode().getCoding()
-            .stream()
-            .anyMatch(coding -> COMMENT_NOTE_CODE.equals(coding.getCode()))
+        return hasCode(observation.getCode(), List.of(COMMENT_NOTE_CODE))
             ? CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
     }
 
@@ -335,7 +334,7 @@ public class ObservationMapper {
     }
 
     private boolean observationHasNonCommentNoteCode(Observation observation) {
-        return observation.hasCode() && !CodeableConceptMappingUtils.hasCode(observation.getCode(), List.of(COMMENT_NOTE_CODE));
+        return observation.hasCode() && !hasCode(observation.getCode(), List.of(COMMENT_NOTE_CODE));
     }
 
     private String prepareCodeElement(Observation observation) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -269,11 +269,11 @@ public class ObservationMapper {
         return Optional.empty();
     }
 
-    private CommentType prepareCommentType(Observation observation){
+    private CommentType prepareCommentType(Observation observation) {
         return observation.getCode().getCoding()
             .stream()
-            .anyMatch(coding -> COMMENT_NOTE_CODE.equals(coding.getCode())) ?
-            CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
+            .anyMatch(coding -> COMMENT_NOTE_CODE.equals(coding.getCode()))
+            ? CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
     }
 
     private String mapObservationToNarrativeStatement(MultiStatementObservationHolder holder, String comment, String commentType) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
@@ -78,6 +78,7 @@ public class ObservationMapperTest {
     private static final String OBSERVATION_COMPOUND_STATEMENT_WITH_REFERENCE_RANGE_AND_INTERPRETATION_XML =
         OBSERVATION_TEST_FILE_DIRECTORY + "observation_compound_statement_with_reference_range_and_interpretation.xml";
 
+    private static final Observation OBSERVATION_WITH_COMMENT_NOTE_CODE = (Observation) new Observation()
 
     @Mock
     private IdMapper idMapper;

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
@@ -78,7 +78,6 @@ public class ObservationMapperTest {
     private static final String OBSERVATION_COMPOUND_STATEMENT_WITH_REFERENCE_RANGE_AND_INTERPRETATION_XML =
         OBSERVATION_TEST_FILE_DIRECTORY + "observation_compound_statement_with_reference_range_and_interpretation.xml";
 
-    private static final Observation OBSERVATION_WITH_COMMENT_NOTE_CODE = (Observation) new Observation()
 
     @Mock
     private IdMapper idMapper;

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_1.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_1.xml
@@ -46,7 +46,7 @@ NEGATIVE
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="Mapped-From-Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151704
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_2.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_2.xml
@@ -35,7 +35,7 @@
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="Mapped-From-Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_3.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_3.xml
@@ -44,7 +44,7 @@ Test not available</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="Mapped-From-Observation/D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_with_data_absent_reason_and_interpretation_and_body_site_and_method.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_compound_statement_with_data_absent_reason_and_interpretation_and_body_site_and_method.xml
@@ -92,7 +92,7 @@ Method: Method text 1</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="Mapped-From-Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151704
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
@@ -334,7 +334,7 @@ NEGATIVE
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151704
 
 (q) - Normal - No Action</text>
@@ -411,7 +411,7 @@ CommentDate:20201215151704
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>
@@ -497,7 +497,7 @@ Test not available</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-observations-inside-report.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-observations-inside-report.xml
@@ -130,7 +130,7 @@
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100123140354
 
 This is some random free text</text>

--- a/service/src/test/resources/uat/output/TC4/9465700088_Mold_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4/9465700088_Mold_full_20210119.xml
@@ -3181,7 +3181,7 @@ Interpretation: HI - Above high reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="44598FC3-DB57-4303-8B26-7D058F2B3510"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151830
 
 (q) - Abnormal - Contact Patient</text>
@@ -3253,7 +3253,7 @@ Interpretation: HI - Above high reference limit</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="46218E0A-240A-47A3-9793-2CA43C848EDB"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151830
 
 (q) - Abnormal - Contact Patient</text>
@@ -3838,7 +3838,7 @@ Quantity: 1750.000 mL
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="E4E199D1-E516-408C-9D3A-32BD4B9329FA"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151809
 
 (q) - Normal - No Action</text>
@@ -4645,7 +4645,7 @@ CommentDate:20100223000000
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="AE72CCBA-F60B-46D1-B875-57746102E3A7"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151742
 
 (q) - Normal - No Action</text>
@@ -4701,7 +4701,7 @@ CommentDate:20201215151742
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="543443CB-EFAA-4D57-8D06-9FDC5A34FD6A"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151742
 
 (q) - Normal - No Action</text>
@@ -4874,7 +4874,7 @@ Interpretation: LO - Below low reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="4264DD9C-01B2-4F68-A222-E3B48540496D"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151742
 
 (q) - Abnormal - Contact Patient</text>
@@ -5148,7 +5148,7 @@ Interpretation: LO - Below low reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="2BCEAA81-6CD9-4DD6-ABD2-0FADBD472DA4"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151743
 
 (q) - Abnormal - Contact Patient</text>
@@ -5447,7 +5447,7 @@ Status: unknown</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="F3D9CD05-FBDA-473A-8FEA-37B31D0DACA9"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151733
 
 (q) - Normal - No Action</text>
@@ -5513,7 +5513,7 @@ IgE House Dust Mite Weak Pos (RAST grade 1)</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="100FAB31-CFAD-4AC4-945D-44930E2A5946"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151733
 
 (q) - Normal - No Action</text>
@@ -5775,7 +5775,7 @@ NEGATIVE
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="51CBEE3D-0661-4B94-84D6-28B3030FC258"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151704
 
 (q) - Normal - No Action</text>
@@ -5854,7 +5854,7 @@ CommentDate:20201215151704
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="01D94EF7-2048-4A7E-8C7E-FD49EB470E93"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>
@@ -5942,7 +5942,7 @@ Test not available</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="B00024B5-0E08-4336-A94C-4726C6DE21A7"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>
@@ -6345,7 +6345,7 @@ Status: unknown</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="616257C9-D034-4DB7-9E71-41CE4CCF7399"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151650
 
 (q) - Normal - No Action</text>
@@ -6828,7 +6828,7 @@ Status: unknown</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="13B6561A-F0BC-4781-BDAF-3DB003A69157"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151633
 
 (q) - Normal - No Action</text>
@@ -7106,7 +7106,7 @@ Other bacteria of doubtful significance</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="52A74F19-B80D-449E-BD93-728B012F1E90"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151612
 
 (q) - Normal - No Action</text>
@@ -7690,7 +7690,7 @@ Interpretation: PA - Potentially abnormal
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="8A11A952-650A-4C2B-9F66-E9A0BD7B72A8"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152510
 
 (q) - Abnormal - Contact Patient</text>
@@ -7909,7 +7909,7 @@ NEGATIVE</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="3AB98D31-BC1C-40C9-B476-3E4012FBD72E"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152501
 
 (q) - Normal - No Action</text>
@@ -7976,7 +7976,7 @@ Oligoclonals detected in both sera and CSF</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="037C249B-6739-441B-A054-7E0C0D77E864"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152502
 
 (q) - Normal - No Action</text>
@@ -8043,7 +8043,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="4C654B41-5A11-48A9-A916-67B0342B9C86"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152502
 
 (q) - Normal - No Action</text>
@@ -8108,7 +8108,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="DBD0E0F1-7A49-4222-84F6-FFD204488AB1"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152502
 
 (q) - Normal - No Action</text>
@@ -8175,7 +8175,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="5321E409-CB3A-42A1-B420-912A28D8D4A0"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8240,7 +8240,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="E8292FF4-0C6C-4880-AF51-092D14DF2ABD"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8307,7 +8307,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="88FD4D53-503C-44F3-B6AF-B04DC69DFD1D"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8374,7 +8374,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="2B44737A-1BFA-4F1C-ACDC-B05F4A7BDF6B"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8439,7 +8439,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="13E22FCC-DCA1-4A43-992A-26D70BC95B92"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8506,7 +8506,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="AA6FA4B6-D845-481E-975C-5FD99EF1B616"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8573,7 +8573,7 @@ Equivocal Result</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="256360F1-27CD-4F3C-81FF-3EF8C4DDF09F"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152504
 
 (q) - Normal - No Action</text>
@@ -8860,7 +8860,7 @@ U=Unsuitable for analysis</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="0DA57B33-6639-441B-96B7-F1488A8A1637"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152445
 
 (q) - Abnormal - Contact Patient</text>
@@ -9012,7 +9012,7 @@ U=Unsuitable,due to delay in delivery.</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="C9E244C2-5966-49B1-8968-B786EB42A551"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152449
 
 (q) - Normal - No Action</text>
@@ -9084,7 +9084,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="03416D2D-8A6E-4419-92C5-5ECCF2F7C13A"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152450
 
 (q) - Abnormal - Contact Patient</text>
@@ -9156,7 +9156,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="8ED56254-7EA1-40E4-BFFE-8FBDB0437BEE"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152450
 
 (q) - Abnormal - Contact Patient</text>
@@ -9228,7 +9228,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="CF33B5B6-0D1A-45A5-A07A-57B75DA2B34E"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152450
 
 (q) - Abnormal - Contact Patient</text>
@@ -9388,7 +9388,7 @@ No other bony abnormality seen. The IUCD is noted in situ.
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="23137F83-2549-496B-8AE9-120FDFE6E932"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108155909
 
 (q) - Normal - No Action</text>
@@ -9410,7 +9410,7 @@ CommentDate:20210108155909
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="23137F83-2549-496B-8AE9-120FDFE6E932"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108155909
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/uat/output/TC4/9465701718_Guerra_full_20210119.xml
+++ b/service/src/test/resources/uat/output/TC4/9465701718_Guerra_full_20210119.xml
@@ -1402,7 +1402,7 @@ Interpretation: PA - Potentially abnormal
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="71F21980-0BAB-4831-944C-365717037140"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326140443
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3133,7 +3133,7 @@ U=Unsuitable for analysis</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="9689E7D7-DD8B-4981-89D4-A2CA6C26DBE5"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134544
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3284,7 +3284,7 @@ U=Unsuitable,due to delay in delivery.</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="F5CD548F-D87B-47BC-8E09-CBEB6BAFAF50"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Normal - No Action</text>
@@ -3356,7 +3356,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="69B9FED1-59E4-4892-BB53-F4FE54715057"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Abnormal - No Action</text>
@@ -3428,7 +3428,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="DE904918-5B6F-405B-9731-F9C528C98F2C"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3500,7 +3500,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="855869E7-17B8-42BE-84FE-E3EB14492478"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3778,7 +3778,7 @@ Interpretation: HI - Above high reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="04EE715B-E2D6-423C-9EBE-74E9426D12A8"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3850,7 +3850,7 @@ Interpretation: HI - Above high reference limit</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="FADF9447-2BCB-48A9-8C22-E591421810BD"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3906,7 +3906,7 @@ CommentDate:20100209122106
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="03245FA5-238F-4857-878F-975411328E56"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - No Action</text>
@@ -3973,7 +3973,7 @@ Non fasting specimen.</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="C5676D58-9600-424A-BE35-3DDAE0CAC622"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - Normal - No Action</text>
@@ -4240,7 +4240,7 @@ I.M.Screen</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="38324DDE-7ABE-4039-BF78-8E9D334FCA8F"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100201093313
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -4306,7 +4306,7 @@ RBC MORPHOLOGY NORMAL</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="9B331CF2-F4AD-45CE-86B8-5B4EEE7D1317"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100201093313
 
 (EMISTest) - Normal - No Action</text>
@@ -4681,7 +4681,7 @@ CommentDate:20100201093313
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="ED202B1D-FD90-4477-95D1-539374CA06ED"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100201093313
 
 (EMISTest) - Normal - No Action</text>

--- a/service/src/test/resources/uat/output/TC7/9465700088_Mold_full_20210602.xml
+++ b/service/src/test/resources/uat/output/TC7/9465700088_Mold_full_20210602.xml
@@ -3291,7 +3291,7 @@ Interpretation: HI - Above high reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="22E43D5F-BFFE-4336-A9E1-FE9B094996FE"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151830
 
 (q) - Abnormal - Contact Patient</text>
@@ -3363,7 +3363,7 @@ Interpretation: HI - Above high reference limit</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="54D4358A-453C-4047-AFB7-0D465ACD05C5"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151830
 
 (q) - Abnormal - Contact Patient</text>
@@ -3963,7 +3963,7 @@ Quantity: 1750.000 mL
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="70EACDF9-9F82-4111-BD75-F0263D662431"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151809
 
 (q) - Normal - No Action</text>
@@ -4790,7 +4790,7 @@ CommentDate:20100223000000
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="FB01369F-2A94-4D0B-AC2F-843879B69915"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151742
 
 (q) - Normal - No Action</text>
@@ -4846,7 +4846,7 @@ CommentDate:20201215151742
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="9C3E35CC-3181-4873-AC6E-50E7C035112A"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151742
 
 (q) - Normal - No Action</text>
@@ -5019,7 +5019,7 @@ Interpretation: LO - Below low reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="DAFE1D63-316B-4368-8D72-D9FA8D893D19"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151742
 
 (q) - Abnormal - Contact Patient</text>
@@ -5293,7 +5293,7 @@ Interpretation: LO - Below low reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="B6B35921-F45E-4397-8732-A37433A523B5"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151743
 
 (q) - Abnormal - Contact Patient</text>
@@ -5618,7 +5618,7 @@ ReportStatus: Preliminary (interim) result</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="C4200E9F-5355-4EFA-A908-602A25619730"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151733
 
 (q) - Normal - No Action</text>
@@ -5684,7 +5684,7 @@ IgE House Dust Mite Weak Pos (RAST grade 1)</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="7A0397D7-3EAC-4407-92E2-5535EC027F73"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151733
 
 (q) - Normal - No Action</text>
@@ -5956,7 +5956,7 @@ NEGATIVE
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="FE49A882-4A7A-444D-B903-8536413D835E"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151704
 
 (q) - Normal - No Action</text>
@@ -6035,7 +6035,7 @@ CommentDate:20201215151704
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="8ECDA0B4-E06F-4882-8D35-255F6BB79187"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>
@@ -6123,7 +6123,7 @@ Test not available</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="2C266175-D484-4554-B5D2-46664E36BBF3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151713
 
 (q) - Normal - No Action</text>
@@ -6531,7 +6531,7 @@ Status: unknown</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="8E5FDD72-0063-4082-A3F8-3DF354A0D14A"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151650
 
 (q) - Normal - No Action</text>
@@ -7024,7 +7024,7 @@ Status: unknown</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="513D7148-C947-44E5-8CAB-E197E1F6F310"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151633
 
 (q) - Normal - No Action</text>
@@ -7312,7 +7312,7 @@ Other bacteria of doubtful significance</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="620368E4-FEF1-411A-B539-83B8A5FFF989"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20201215151612
 
 (q) - Normal - No Action</text>
@@ -7911,7 +7911,7 @@ Interpretation: PA - Potentially abnormal
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="3FA6C543-2AE9-4AE7-A2DA-4E2A85FBD9F3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152510
 
 (q) - Abnormal - Contact Patient</text>
@@ -8135,7 +8135,7 @@ NEGATIVE</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="DBD0E0F1-7A49-4222-84F6-FFD204488AB1"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152501
 
 (q) - Normal - No Action</text>
@@ -8202,7 +8202,7 @@ Oligoclonals detected in both sera and CSF</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="E8292FF4-0C6C-4880-AF51-092D14DF2ABD"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152502
 
 (q) - Normal - No Action</text>
@@ -8269,7 +8269,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="88FD4D53-503C-44F3-B6AF-B04DC69DFD1D"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152502
 
 (q) - Normal - No Action</text>
@@ -8334,7 +8334,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="2B44737A-1BFA-4F1C-ACDC-B05F4A7BDF6B"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152502
 
 (q) - Normal - No Action</text>
@@ -8401,7 +8401,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="13E22FCC-DCA1-4A43-992A-26D70BC95B92"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8466,7 +8466,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="AA6FA4B6-D845-481E-975C-5FD99EF1B616"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8533,7 +8533,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="256360F1-27CD-4F3C-81FF-3EF8C4DDF09F"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8600,7 +8600,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="E33B164C-8182-4493-BFBA-87DE4DF252C7"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8665,7 +8665,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="A7C34838-DB35-42C0-96B6-B3F798210712"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8732,7 +8732,7 @@ NEGATIVE</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="58E1A9E7-8274-4994-A607-46FEC1765ACF"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152503
 
 (q) - Normal - No Action</text>
@@ -8799,7 +8799,7 @@ Equivocal Result</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="47B6FF4C-17CC-44F8-B103-DDD4E5066A38"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152504
 
 (q) - Normal - No Action</text>
@@ -9091,7 +9091,7 @@ U=Unsuitable for analysis</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="E207BF0E-7F80-4E1C-9BC7-15736EDA421C"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152445
 
 (q) - Abnormal - Contact Patient</text>
@@ -9243,7 +9243,7 @@ U=Unsuitable,due to delay in delivery.</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="FACD1857-0DD4-49B6-8132-3A377DCCDE77"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152449
 
 (q) - Normal - No Action</text>
@@ -9315,7 +9315,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="78252A19-1D51-4C94-B7EF-978CA58CB08C"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152450
 
 (q) - Abnormal - Contact Patient</text>
@@ -9387,7 +9387,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="DDDD42B3-E3FC-442F-B195-78F204A844EA"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152450
 
 (q) - Abnormal - Contact Patient</text>
@@ -9459,7 +9459,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="5F9C871A-9927-4F9F-ACF1-ABB290B70D29"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108152450
 
 (q) - Abnormal - Contact Patient</text>
@@ -9625,7 +9625,7 @@ No other bony abnormality seen. The IUCD is noted in situ.
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="3E5813A7-FBD4-4E31-84AD-AF5249DB055B"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20210108155909
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/uat/output/TC7/9465701718_Guerra_full_20210602.xml
+++ b/service/src/test/resources/uat/output/TC7/9465701718_Guerra_full_20210602.xml
@@ -1555,7 +1555,7 @@ Interpretation: PA - Potentially abnormal
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="409C8344-FFB9-40C9-A802-D71602F56263"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326140443
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3306,7 +3306,7 @@ U=Unsuitable for analysis</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="B1310011-B620-48D7-A381-2BF0335C5B3D"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134544
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3457,7 +3457,7 @@ U=Unsuitable,due to delay in delivery.</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="C3FE7EB4-3F56-4C41-A04C-46DA81F4E3A9"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Normal - No Action</text>
@@ -3529,7 +3529,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="85522AAC-80B6-4F73-BD34-50825EF0E45C"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Abnormal - No Action</text>
@@ -3601,7 +3601,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="D3041FE6-2820-4938-8024-1FC80F2A694F"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3673,7 +3673,7 @@ Interpretation: OR - Outside reference range</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="200FC1C9-6A9F-47CE-A4F7-50199281322D"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100326134545
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -3957,7 +3957,7 @@ Interpretation: HI - Above high reference limit</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="4F617D37-6109-4A36-B6DA-D6A29436EC15"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -4029,7 +4029,7 @@ Interpretation: HI - Above high reference limit</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="C5676D58-9600-424A-BE35-3DDAE0CAC622"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -4085,7 +4085,7 @@ CommentDate:20100209122106
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="5667A85C-4AEF-4431-987D-B29A9A267DD5"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - No Action</text>
@@ -4152,7 +4152,7 @@ Non fasting specimen.</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="8EA77BE5-9F13-455B-B835-5B9825187E0C"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100209122106
 
 (EMISTest) - Normal - No Action</text>
@@ -4429,7 +4429,7 @@ I.M.Screen</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="3FE921FD-5A7C-49A7-BF85-591FC6C8933C"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100201093313
 
 (EMISTest) - Abnormal - Contact Patient</text>
@@ -4495,7 +4495,7 @@ RBC MORPHOLOGY NORMAL</text>
             <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="9096D5A1-7370-4C51-AE78-52A89E2F6B63"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100201093313
 
 (EMISTest) - Normal - No Action</text>
@@ -5384,7 +5384,7 @@ ReportStatus: Supplementary result</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="B06F16C9-95BA-41C5-99DA-902FC5B0B72B"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100201093313
 
 (EMISTest) - Normal - No Action</text>


### PR DESCRIPTION
[NIAD-1759](https://gpitbjss.atlassian.net/browse/NIAD-1759) fix

- Comments in Observations that contain USER_COMMENT_CODE are treated as USER_COMMENT CommentType