### PR TITLE
NIAD-1795: MHS mock adaptor PoC

### DIFF
--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/MhsMockRequestsJournal.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/MhsMockRequestsJournal.java
@@ -46,7 +46,7 @@ public class MhsMockRequestsJournal {
     public void deleteRequestsJournal() {
         var statusCode = client.send(buildDeleteRequest(), HttpResponse.BodyHandlers.ofString()).statusCode();
         if (statusCode != 200) {
-            throw new RuntimeException("Unexpected status code: " + statusCode);
+            throw new RuntimeException("Unexpected status_code=" + statusCode);
         }
     }
 

--- a/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/service/MDCService.java
+++ b/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/service/MDCService.java
@@ -1,0 +1,17 @@
+package uk.nhs.adaptors.mockmhsservice.service;
+
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MDCService {
+    private static final String MDC_CONVERSATION_ID_KEY = "ConversationId";
+
+    public void applyConversationId(String id) {
+        MDC.put(MDC_CONVERSATION_ID_KEY, id);
+    }
+
+    public void resetAllMdcKeys() {
+        MDC.clear();
+    }
+}

--- a/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/service/MockMhsService.java
+++ b/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/service/MockMhsService.java
@@ -1,8 +1,10 @@
 package uk.nhs.adaptors.mockmhsservice.service;
 
-import static org.springframework.http.HttpStatus.ACCEPTED;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -10,17 +12,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jms.JmsException;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.mockmhsservice.common.MockMHSException;
 import uk.nhs.adaptors.mockmhsservice.common.OutboundMessage;
 import uk.nhs.adaptors.mockmhsservice.common.ResourceReader;
 import uk.nhs.adaptors.mockmhsservice.producer.InboundProducer;
+
+import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @RestController
 @Slf4j
@@ -93,7 +91,7 @@ public class MockMhsService {
             headers.setContentType(MediaType.TEXT_XML);
             return new ResponseEntity<>(headers, ACCEPTED);
         }
-        LOGGER.error("Error could not handle request header Interaction-Id {}", interactionId);
+        LOGGER.error("Error could not handle request header Interaction-Id: {}", interactionId);
         return new ResponseEntity<>(INTERNAL_SERVER_ERROR_RESPONSE, headers, INTERNAL_SERVER_ERROR);
     }
 

--- a/mock-mhs-adaptor/src/main/resources/logback.xml
+++ b/mock-mhs-adaptor/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="TEXT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${MHS_MOCK_LOGGING_FORMAT:-%d{yyyy-MM-dd HH:mm:ss.SSS} Level=%-5level Logger=%logger{36} ConversationId=%X{ConversationId} Thread="%thread" Message="%msg"%n}
+            </pattern>
+        </encoder>
+    </appender>
+
+
+    <root level="${MHS_MOCK_ROOT_LOGGING_LEVEL:-WARN}">
+        <appender-ref ref="TEXT}"/>
+    </root>
+
+    <logger name="uk.nhs.adaptors.mockmhsservice" level="${MHS_MOCK_LOGGING_LEVEL:-INFO}" />
+    <logger name="reactor.netty.http.client" level="${MHS_MOCK_LOGGING_LEVEL:-WARN}" />
+</configuration>

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
@@ -1,12 +1,5 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,15 +7,21 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
-import uk.nhs.adaptors.gp2gp.mhs.exception.NonExistingInteractionIdException;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.ehr.request.EhrExtractRequestHandler;
 import uk.nhs.adaptors.gp2gp.mhs.InvalidInboundMessageException;
+import uk.nhs.adaptors.gp2gp.mhs.exception.NonExistingInteractionIdException;
 import uk.nhs.adaptors.gp2gp.testcontainers.ActiveMQExtension;
 import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith({SpringExtension.class, MongoDBExtension.class, ActiveMQExtension.class})
 @SpringBootTest
@@ -77,7 +76,7 @@ public class EhrContinueTest {
         Exception exception = assertThrows(NonExistingInteractionIdException.class,
             () -> ehrExtractRequestHandler.handleContinue(conversationId, CONTINUE_ACKNOWLEDGEMENT));
 
-        assertThat(exception.getMessage()).isEqualTo("Received a Continue message that is not recognised with Conversation-Id: '"
+        assertThat(exception.getMessage()).isEqualTo("Received a Continue message that is not recognised with conversation_id: '"
             + conversationId + "'");
         verify(taskDispatcher, never()).createTask(any());
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/mongo/MongoClientConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/mongo/MongoClientConfiguration.java
@@ -1,19 +1,17 @@
 package uk.nhs.adaptors.gp2gp.common.mongo;
 
-import java.time.Duration;
-
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoClientSettings;
-
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
 
 @Configuration
 @ConfigurationProperties(prefix = "gp2gp.mongodb")
@@ -72,12 +70,12 @@ public class MongoClientConfiguration extends AbstractMongoClientConfiguration {
             LOGGER.debug("Including a username and password in the mongo connection string");
             connectionString += username + ":" + password + "@";
         } else {
-            LOGGER.info("No mongodb username or password is configured. Will use an anonymous connection.");
+            LOGGER.info("Mongodb username or password are not configured. Using an anonymous connection.");
         }
-        LOGGER.debug("The generated connection string will used host '{}' and port '{}'", host, port);
+        LOGGER.debug("Using host: {} port: {} in the generated connection string.", host, port);
         connectionString += host + ":" + port;
         if (StringUtils.isNotBlank(options)) {
-            LOGGER.debug("The generated connection will use use options '{}'", options);
+            LOGGER.debug("Using options: '{}' in the generated connection string.", options);
             connectionString += "/?" + options;
         } else {
             LOGGER.warn("No options for the mongodb connection string were provided. "

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ProcessFailureHandlingService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ProcessFailureHandlingService.java
@@ -34,11 +34,13 @@ public class ProcessFailureHandlingService {
                     return true;
                 })
                 .orElseGet(() -> {
-                    LOGGER.warn("EHR extract status not found for Conversation-Id {}. Can't update it with error information.");
+                    LOGGER.warn(
+                        "EHR extract status not found for conversation_id: {}. Can't update it with error information.",
+                        conversationId);
                     return false;
                 });
         } catch (Exception e) {
-            LOGGER.error("An error occurred when closing a failed process for Conversation-Id: {}", conversationId, e);
+            LOGGER.error("An error occurred when closing a failed process for conversation_id: {}", conversationId, e);
             return false;
         }
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskDispatcher.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskDispatcher.java
@@ -1,19 +1,17 @@
 package uk.nhs.adaptors.gp2gp.common.task;
 
-import static uk.nhs.adaptors.gp2gp.common.task.TaskHandler.TASK_TYPE_HEADER_NAME;
-
-import javax.jms.TextMessage;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.jms.TextMessage;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import static uk.nhs.adaptors.gp2gp.common.task.TaskHandler.TASK_TYPE_HEADER_NAME;
 
 @Component
 @Slf4j
@@ -30,7 +28,7 @@ public class TaskDispatcher {
         try {
             String messagePayload = objectMapper.writeValueAsString(taskDefinition);
             sendMessage(messagePayload, taskDefinition.getTaskType().getTaskName());
-            LOGGER.info("Created new {} task with id {}",
+            LOGGER.info("Sent {} task id: {}",
                 taskDefinition.getTaskType().getTaskName(),
                 taskDefinition.getTaskId());
         } catch (JsonProcessingException e) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/utils/Jms.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/utils/Jms.java
@@ -1,0 +1,15 @@
+package uk.nhs.adaptors.gp2gp.common.utils;
+
+import lombok.SneakyThrows;
+
+import javax.jms.Message;
+import java.text.SimpleDateFormat;
+
+public class Jms {
+    @SneakyThrows
+    public static String getJmsMessageTimestamp(Message message) {
+        var timestampAsDate = new java.util.Date(message.getJMSTimestamp());
+        var dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        return dateFormatter.format(timestampAsDate);
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/DetectDocumentsSentService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/DetectDocumentsSentService.java
@@ -1,10 +1,10 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.nhs.adaptors.gp2gp.common.task.TaskType;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 
 @Slf4j
@@ -15,7 +15,7 @@ public class DetectDocumentsSentService {
 
     public void beginSendingPositiveAcknowledgement(EhrExtractStatus ehrExtractStatus) {
         if (EhrExtractStatusValidator.areAllDocumentsSent(ehrExtractStatus)) {
-            LOGGER.info("All send documents have finished, Creating Positive Acknowledgement Task");
+            LOGGER.info("Finished sending all documents. Creating {} task", TaskType.SEND_ACKNOWLEDGEMENT);
             sendAcknowledgementTaskDispatcher.sendPositiveAcknowledgement(ehrExtractStatus);
         }
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -3,12 +3,6 @@ package uk.nhs.adaptors.gp2gp.ehr;
 import com.mongodb.client.result.UpdateResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -17,16 +11,20 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
-import uk.nhs.adaptors.gp2gp.mhs.exception.MessageOutOfOrderException;
-import uk.nhs.adaptors.gp2gp.mhs.exception.NonExistingInteractionIdException;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus.EhrReceivedAcknowledgement;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails;
 import uk.nhs.adaptors.gp2gp.gpc.GetGpcDocumentTaskDefinition;
 import uk.nhs.adaptors.gp2gp.gpc.GetGpcStructuredTaskDefinition;
+import uk.nhs.adaptors.gp2gp.mhs.exception.MessageOutOfOrderException;
+import uk.nhs.adaptors.gp2gp.mhs.exception.NonExistingInteractionIdException;
 import uk.nhs.adaptors.gp2gp.mhs.model.OutboundMessage;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -212,11 +210,11 @@ public class EhrExtractStatusService {
                 EhrExtractStatus.class);
 
             if (ehrExtractStatus == null) {
-                throw new EhrExtractException("Received a Continue message with a Conversation-Id '" + conversationId
+                throw new EhrExtractException("Received a Continue message with a conversation_id '" + conversationId
                     + "' that is not recognised");
             }
 
-            LOGGER.info("Database successfully updated with EHRContinue, Conversation-Id: " + conversationId);
+            LOGGER.info("Database successfully updated with EHRContinue");
             return Optional.of(ehrExtractStatus);
         } else {
             return Optional.empty();
@@ -249,11 +247,11 @@ public class EhrExtractStatusService {
                 EhrExtractStatus.class);
 
             if (ehrExtractStatus == null) {
-                throw new EhrExtractException("Received an ACK message with a Conversation-Id '" + conversationId
+                throw new EhrExtractException("Received an ACK message with a conversation_id '" + conversationId
                     + "' that is not recognised");
             }
 
-            LOGGER.info("Database successfully updated with EHRAcknowledgement, Conversation-Id: " + conversationId);
+            LOGGER.info("Database successfully updated with EHRAcknowledgement, conversation_id: " + conversationId);
         }
     }
 
@@ -363,13 +361,13 @@ public class EhrExtractStatusService {
 
         if (ehrExtractStatus == null) {
             throw new EhrExtractException(format(
-                "Couldn't update EHR status with error information because it doesn't exist. Conversation-Id: %s",
+                "Couldn't update EHR status with error information because it doesn't exist conversation_id: %s",
                 conversationId
             ));
         }
 
         LOGGER.info(
-            "EHR status record successfully updated in the database with error information. Conversation-Id: {}",
+            "EHR status record successfully updated in the database with error information conversation_id: {}",
             conversationId
         );
 
@@ -455,7 +453,7 @@ public class EhrExtractStatusService {
         }
 
         if (ehrExtractStatus.getEhrReceivedAcknowledgement() != null) {
-            LOGGER.warn("Received an ACK message with a Conversation-Id '" + conversationId
+            LOGGER.warn("Received an ACK message with a conversation_id '" + conversationId
                 + "' that is duplicate");
             return true;
         }
@@ -472,7 +470,7 @@ public class EhrExtractStatusService {
         }
 
         if (ehrExtractStatus.getEhrContinue() != null) {
-            LOGGER.warn("Received a Continue message with a Conversation-Id '" + conversationId
+            LOGGER.warn("Received a Continue message with a conversation_id '" + conversationId
                 + "' that is duplicate");
             return true;
         }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendAcknowledgementExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendAcknowledgementExecutor.java
@@ -3,17 +3,14 @@ package uk.nhs.adaptors.gp2gp.ehr;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mustachejava.Mustache;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.service.TimestampService;
 import uk.nhs.adaptors.gp2gp.common.task.TaskExecutor;
@@ -46,7 +43,6 @@ public class SendAcknowledgementExecutor implements TaskExecutor<SendAcknowledge
     @Override
     @SneakyThrows
     public void execute(SendAcknowledgementTaskDefinition sendAcknowledgementTaskDefinition) {
-        LOGGER.info("Sending application acknowledgement from the adaptor to the requesting system");
         var ackMessageId = randomIdGeneratorService.createNewId();
 
         var sendAckTemplateParams = SendAckTemplateParameters.builder()
@@ -70,8 +66,8 @@ public class SendAcknowledgementExecutor implements TaskExecutor<SendAcknowledge
     }
 
     private void sendToMHS(SendAcknowledgementTaskDefinition taskDefinition, String ackMessageId, String requestBody) {
-        LOGGER.info("Sending ACK message to MHS. ACK message Id: {} Conversation id: {} EhrRequest id {} ", ackMessageId,
-            taskDefinition.getConversationId(), taskDefinition.getEhrRequestMessageId());
+        LOGGER.info("Sending ACK message to MHS. ACK message_id: {} conversation_id: {} ehrRequest_id: {} ",
+            ackMessageId, taskDefinition.getConversationId(), taskDefinition.getEhrRequestMessageId());
 
         var request = mhsRequestBuilder.buildSendAcknowledgement(
             requestBody, taskDefinition.getFromOdsCode(), taskDefinition.getConversationId(), ackMessageId);
@@ -89,7 +85,7 @@ public class SendAcknowledgementExecutor implements TaskExecutor<SendAcknowledge
     }
 
     private void updateEhrExtractStatus(SendAcknowledgementTaskDefinition taskDefinition, String ackMessageId) {
-        LOGGER.info("Updating EhrExtractStatus with ACK message Id: {} Conversation id: {}", ackMessageId,
+        LOGGER.info("Updating EhrExtractStatus with ACK message_id: {} conversation_id: {}", ackMessageId,
             taskDefinition.getConversationId());
 
         ehrExtractStatusService.updateEhrExtractStatusAcknowledgement(
@@ -99,7 +95,7 @@ public class SendAcknowledgementExecutor implements TaskExecutor<SendAcknowledge
     }
 
     private void updateEhrExtractStatus(SendAcknowledgementTaskDefinition taskDefinition, String ackMessageId, String updatedAt) {
-        LOGGER.info("Updating EhrExtractStatus with pending ACK message Id: {} Conversation id: {}", ackMessageId,
+        LOGGER.info("Updating EhrExtractStatus with pending ACK message_id: {} conversation_id: {}", ackMessageId,
             taskDefinition.getConversationId());
 
         ehrExtractStatusService.updateEhrExtractStatusAcknowledgement(

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendAcknowledgementTaskDispatcher.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendAcknowledgementTaskDispatcher.java
@@ -1,16 +1,15 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
-import static uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition.ACK_TYPE_CODE;
-import static uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition.NACK_TYPE_CODE;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+
+import static uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition.ACK_TYPE_CODE;
+import static uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition.NACK_TYPE_CODE;
 
 @Service
 @Slf4j
@@ -24,7 +23,7 @@ public class SendAcknowledgementTaskDispatcher {
             getAcknowledgementTaskDefinitionBuilder(ehrExtractStatus, ACK_TYPE_CODE);
 
         taskDispatcher.createTask(taskDefinitionBuilder.build());
-        LOGGER.info("SendAcknowledgementTaskDefinition for ACK added to task queue");
+        LOGGER.info("Sent {} task with ACK: {}", SendAcknowledgementTaskDefinition.class.getSimpleName(), ACK_TYPE_CODE);
     }
 
     public void sendNegativeAcknowledgement(EhrExtractStatus ehrExtractStatus, String reasonCode, String reasonMessage) {
@@ -34,7 +33,7 @@ public class SendAcknowledgementTaskDispatcher {
         taskDefinitionBuilder.detail(reasonMessage);
 
         taskDispatcher.createTask(taskDefinitionBuilder.build());
-        LOGGER.info("SendAcknowledgementTaskDefinition for NACK added to task queue");
+        LOGGER.info("Sent {} task with NACK: {}", SendAcknowledgementTaskDefinition.class.getSimpleName(), NACK_TYPE_CODE);
     }
 
     private SendAcknowledgementTaskDefinition.SendAcknowledgementTaskDefinitionBuilder<?, ?> getAcknowledgementTaskDefinitionBuilder(

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutor.java
@@ -49,7 +49,6 @@ public class SendDocumentTaskExecutor implements TaskExecutor<SendDocumentTaskDe
     @SneakyThrows
     @Override
     public void execute(SendDocumentTaskDefinition taskDefinition) {
-        LOGGER.info("SendDocument task was created, Sending EHR Document to GP");
         var storageDataWrapper = storageConnectorService.downloadFile(taskDefinition.getDocumentName());
         var mainMessageId = taskDefinition.getMessageId();
         var mainDocumentId = taskDefinition.getDocumentId();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendEhrExtractCoreTaskDispatcher.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendEhrExtractCoreTaskDispatcher.java
@@ -1,10 +1,9 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
@@ -28,6 +27,6 @@ public class SendEhrExtractCoreTaskDispatcher {
             .build();
 
         taskDispatcher.createTask(sendEhrExtractCoreTaskDefinition);
-        LOGGER.info("SendEhrExtractCoreTaskDefinition added to task queue.");
+        LOGGER.info("{} added to task queue.", SendEhrExtractCoreTaskDefinition.class.getSimpleName());
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendEhrExtractCoreTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendEhrExtractCoreTaskExecutor.java
@@ -31,8 +31,6 @@ public class SendEhrExtractCoreTaskExecutor implements TaskExecutor<SendEhrExtra
     @Override
     @SneakyThrows
     public void execute(SendEhrExtractCoreTaskDefinition sendEhrExtractCoreTaskDefinition) {
-        LOGGER.info("SendEhrExtractCore task was created, Sending EHR extract to Spine");
-
         String structuredRecordFilename = GpcFilenameUtils.generateStructuredRecordFilename(
             sendEhrExtractCoreTaskDefinition.getConversationId());
         var storageDataWrapper = storageConnectorService.downloadFile(structuredRecordFilename);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/request/EhrExtractRequestHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/request/EhrExtractRequestHandler.java
@@ -182,8 +182,9 @@ public class EhrExtractRequestHandler {
             .documentId(documentId)
             .externalEhrExtract(externalEhrExtract)
             .build();
+        LOGGER.info("Sending task for document_id: {} document_name: {}", documentId, documentName);
         taskDispatcher.createTask(sendDocumentTaskDefinition);
-        LOGGER.info("Ehr Continue task created for document: " + documentName + ", taskId: " + sendDocumentTaskDefinition.getTaskId());
+
     }
 
     public void handleAcknowledgement(String conversationId, Document payload) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/DetectTranslationCompleteService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/DetectTranslationCompleteService.java
@@ -1,10 +1,10 @@
 package uk.nhs.adaptors.gp2gp.gpc;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.nhs.adaptors.gp2gp.common.task.TaskType;
 import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusValidator;
 import uk.nhs.adaptors.gp2gp.ehr.SendEhrExtractCoreTaskDispatcher;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
@@ -17,7 +17,7 @@ public class DetectTranslationCompleteService {
 
     public void beginSendingCompleteExtract(EhrExtractStatus ehrExtractStatus) {
         if (EhrExtractStatusValidator.isPreparingDataFinished(ehrExtractStatus)) {
-            LOGGER.info("All tasks have finished, Creating SendEhrExtractCore Task");
+            LOGGER.info("All tasks have finished. Sending task {}", TaskType.SEND_EHR_EXTRACT_CORE);
             sendEhrExtractCoreTaskDispatcher.send(ehrExtractStatus);
         }
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -27,8 +27,6 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
     @Override
     @SneakyThrows
     public void execute(GetGpcDocumentTaskDefinition taskDefinition) {
-        LOGGER.info("Execute called from GetGpcDocumentTaskExecutor");
-
         var response = gpcClient.getDocumentRecord(taskDefinition);
 
         var taskId = taskDefinition.getTaskId();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
@@ -1,23 +1,20 @@
 package uk.nhs.adaptors.gp2gp.gpc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import uk.nhs.adaptors.gp2gp.common.configuration.Gp2gpConfiguration;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.storage.StorageConnectorService;
+import uk.nhs.adaptors.gp2gp.common.storage.StorageDataWrapper;
 import uk.nhs.adaptors.gp2gp.common.task.TaskDefinition;
 import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
-import uk.nhs.adaptors.gp2gp.common.storage.StorageDataWrapper;
 import uk.nhs.adaptors.gp2gp.common.task.TaskExecutor;
 import uk.nhs.adaptors.gp2gp.ehr.DocumentTaskDefinition;
 import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusService;
@@ -62,8 +59,6 @@ public class GetGpcStructuredTaskExecutor implements TaskExecutor<GetGpcStructur
     @SneakyThrows
     @Override
     public void execute(GetGpcStructuredTaskDefinition structuredTaskDefinition) {
-        LOGGER.info("Execute called from GetGpcStructuredTaskExecutor");
-
         String hl7TranslatedResponse;
         List<OutboundMessage.Attachment> attachments = new ArrayList<>();
         List<OutboundMessage.ExternalAttachment> externalAttachments;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GpcClient.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GpcClient.java
@@ -41,7 +41,7 @@ public class GpcClient {
     }
 
     private void logRequest(String logTemplate, TaskDefinition taskDefinition, String url) {
-        LOGGER.info(logTemplate,
+        LOGGER.debug(logTemplate,
             taskDefinition.getToAsid(),
             taskDefinition.getFromAsid(),
             url);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/InboundMessageConsumer.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/InboundMessageConsumer.java
@@ -1,15 +1,16 @@
 package uk.nhs.adaptors.gp2gp.mhs;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.gp2gp.common.service.MDCService;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import static uk.nhs.adaptors.gp2gp.common.utils.Jms.getJmsMessageTimestamp;
 
 @Component
 @Slf4j
@@ -21,16 +22,17 @@ public class InboundMessageConsumer {
     @JmsListener(destination = "${gp2gp.amqp.inboundQueueName}")
     public void receive(Message message) throws JMSException {
         var messageID = message.getJMSMessageID();
-        LOGGER.info("Received inbound MHS message {}", messageID);
+        var messageTimestamp = getJmsMessageTimestamp(message);
+        LOGGER.info("Received inbound MHS message_id: {} timestamp: {}", messageID, messageTimestamp);
         try {
             if (inboundMessageHandler.handle(message)) {
                 message.acknowledge();
-                LOGGER.info("Acknowledged inbound MHS message {}", messageID);
+                LOGGER.info("Acknowledged inbound MHS message_id: {}", messageID);
             } else {
-                LOGGER.info("Left inbound MHS message {} on the queue", messageID);
+                LOGGER.info("Leaving inbound MHS message_id: {} on the queue", messageID);
             }
         } catch (Exception e) {
-            LOGGER.error("An error occurred while handing MHS inbound message {}", messageID, e);
+            LOGGER.error("An error occurred while handing inbound MHS message_id: {}", messageID, e);
         } finally {
             mdcService.resetAllMdcKeys();
         }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/MhsClient.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/MhsClient.java
@@ -1,20 +1,17 @@
 package uk.nhs.adaptors.gp2gp.mhs;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Slf4j
 public class MhsClient {
-    private final MhsConfiguration mhsConfiguration;
-
     public String sendMessageToMHS(RequestHeadersSpec<? extends RequestHeadersSpec<?>> request) {
-        LOGGER.info("Mhs Outbound Request, Mhs Outbound Endpoint: {}", mhsConfiguration.getUrl());
+        LOGGER.info("Sending MHS Outbound Request");
 
         return request
             .retrieve()

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/MhsRequestBuilder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/MhsRequestBuilder.java
@@ -39,7 +39,6 @@ public class MhsRequestBuilder {
 
     private final MhsConfiguration mhsConfiguration;
     private final RequestBuilderService requestBuilderService;
-    private final WebClientFilterService webClientFilterService;
 
     public RequestHeadersSpec<?> buildSendEhrExtractCoreRequest(String extractCoreMessage, String conversationId, String fromOdsCode) {
         SslContext sslContext = requestBuilderService.buildSSLContext();
@@ -67,7 +66,8 @@ public class MhsRequestBuilder {
             .builder()
             .exchangeStrategies(requestBuilderService.buildExchangeStrategies())
             .clientConnector(new ReactorClientHttpConnector(httpClient))
-            .filter(webClientFilterService.errorHandlingFilter(WebClientFilterService.RequestType.MHS_OUTBOUND, HttpStatus.ACCEPTED))
+            .filters(filters -> WebClientFilterService
+                .addWebClientFilters(filters, WebClientFilterService.RequestType.MHS_OUTBOUND, HttpStatus.ACCEPTED))
             .baseUrl(mhsConfiguration.getUrl())
             .defaultUriVariables(Collections.singletonMap("url", mhsConfiguration.getUrl()))
             .build();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/MessageOutOfOrderException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/MessageOutOfOrderException.java
@@ -2,7 +2,7 @@ package uk.nhs.adaptors.gp2gp.mhs.exception;
 
 public class MessageOutOfOrderException extends RuntimeException {
     public MessageOutOfOrderException(String messageType, String conversationId) {
-        super("Received a " + messageType + " message that is out of order in message process with a Conversation-Id: '" + conversationId
+        super("Received a " + messageType + " message that is out of order in message process with a conversation_id: '" + conversationId
                 + "'");
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/NonExistingInteractionIdException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/NonExistingInteractionIdException.java
@@ -2,7 +2,7 @@ package uk.nhs.adaptors.gp2gp.mhs.exception;
 
 public class NonExistingInteractionIdException extends RuntimeException {
     public NonExistingInteractionIdException(String messageType, String conversationId) {
-        super("Received a " + messageType + " message that is not recognised with Conversation-Id: '" + conversationId
+        super("Received a " + messageType + " message that is not recognised with conversation_id: '" + conversationId
             + "'");
     }
 }

--- a/vnp/Wiremock/README.md
+++ b/vnp/Wiremock/README.md
@@ -31,3 +31,9 @@ Send GET request to Wiremock:
 The response gets back after the configured 3000ms delay elapses.
 
 Response body contains a FHIR Binary resource with `content` field filled with random 500 characters.
+
+## Logging
+
+Use `--verbose` parameter to make Wiremock log requests. This allows looking up `Conversation-Id` and/or `Correlation-Id` headers.
+Wiremock uses slf4j and logback.xml can be replaced but it is not easy to make it log those headers as separate log fields.
+Some regex expression should be used instead.

--- a/vnp/Wiremock/docker-compose.yml
+++ b/vnp/Wiremock/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - "8080:8080"
     command:
       - -global-response-templating
+      - --verbose


### PR DESCRIPTION
Added logback.xml to MHS mock.
Made MHS mock to log correlation_id. 
Fixed issue where HTTP clients in GP2GP had empty MDC due to using a different thread.
Small logging tweaks. Wiremock logging requests.