### PR TITLE
NIAD-2188 smoke test - string replacement bug

### DIFF
--- a/smoke-tests/src/test/java/util/EnvVarsUtil.java
+++ b/smoke-tests/src/test/java/util/EnvVarsUtil.java
@@ -1,5 +1,8 @@
 package util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class EnvVarsUtil {
 
     public static String replaceContainerUri(String uri, String protocol, String containerName) {
@@ -19,10 +22,20 @@ public class EnvVarsUtil {
         String dockerContainerPath = protocol + "://" + containerName;
 
         if (uri.contains(dockerContainerPath)) {
-            String regex = "(" + protocol + "://)(" + containerName + ")(:\\d+)[A-Za-z/\\d@_-]*";
-            return uri.replaceAll(regex, "$1localhost$3");
-        } else {
-            return uri;
+            String regexWithContainer = "(" + protocol + "://)(" + containerName + ")(:\\d+)[A-Za-z/\\d@_-]*";
+            return uri.replaceAll(regexWithContainer, "$1localhost$3");
         }
+
+        String regexWithoutContainer = "("+ protocol +"://[A-z]*[:\\d+]*)[/@A-z\\d-_]*";
+
+        Pattern pattern = Pattern.compile(regexWithoutContainer);
+        Matcher matcher = pattern.matcher(uri);
+
+        if (matcher.find()) {
+            return uri.replaceAll(regexWithoutContainer, "$1");
+        }
+
+        return uri;
+
     }
 }


### PR DESCRIPTION
Fix bug where gpc smoke test will not extract host from url if the host is not a docker container.