### PR TITLE
Niad 2395 mapping bug unit of measurements

### DIFF
--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -71,8 +71,6 @@ public class EhrExtractTest {
     private static final String NHS_NUMBER_RESPONSE_MISSING_PATIENT_RESOURCE = "2906543841";
     private static final String NHS_NUMBER_MEDICUS_BASED_ON = "9302014592";
     private static final String NHS_NUMBER_INVALID_CONTENT_TYPE_DOC = "9817280691";
-    private static final String NHS_NUMBER_MEDICUS_TEST_UNITS_OF_MEASUREMENT_ASR = "9693142837";
-
     private static final String EHR_EXTRACT_REQUEST_TEST_FILE = "/ehrExtractRequest.json";
     private static final String EHR_EXTRACT_REQUEST_WITHOUT_NHS_NUMBER_TEST_FILE = "/ehrExtractRequestWithoutNhsNumber.json";
     private static final String EHR_EXTRACT_REQUEST_NO_DOCUMENTS = "/ehrExtractRequestWithNoDocuments.json";
@@ -161,13 +159,6 @@ public class EhrExtractTest {
             .hasXPath("/MCCI_IN010000UK13/acknowledgement[@type='Acknowledgement' and @typeCode='AE']/acknowledgementDetail[@type='AcknowledgementDetail' and @typeCode='ER']/code[@code='18']".replace("/", XML_NAMESPACE));
         XmlAssert.assertThat(requestJournal.get(0).getPayload())
             .hasXPath("/MCCI_IN010000UK13/ControlActEvent/reason/justifyingDetectedIssueEvent/code[@code='18']".replace("/", XML_NAMESPACE));
-    }
-
-    @Test
-    public void sendThroughMedicusMeasurementsBugASR() throws IOException, NamingException, JMSException {
-        String conversationId = UUID.randomUUID().toString();
-        String ehrExtractRequest = buildEhrExtractRequest(conversationId, NHS_NUMBER_MEDICUS_TEST_UNITS_OF_MEASUREMENT_ASR, FROM_ODS_CODE_1);
-        MessageQueue.sendToMhsInboundQueue(ehrExtractRequest);
     }
 
     @Test

--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -71,6 +71,7 @@ public class EhrExtractTest {
     private static final String NHS_NUMBER_RESPONSE_MISSING_PATIENT_RESOURCE = "2906543841";
     private static final String NHS_NUMBER_MEDICUS_BASED_ON = "9302014592";
     private static final String NHS_NUMBER_INVALID_CONTENT_TYPE_DOC = "9817280691";
+    private static final String NHS_NUMBER_MEDICUS_TEST_UNITS_OF_MEASUREMENT_ASR = "9693142837";
 
     private static final String EHR_EXTRACT_REQUEST_TEST_FILE = "/ehrExtractRequest.json";
     private static final String EHR_EXTRACT_REQUEST_WITHOUT_NHS_NUMBER_TEST_FILE = "/ehrExtractRequestWithoutNhsNumber.json";
@@ -160,6 +161,13 @@ public class EhrExtractTest {
             .hasXPath("/MCCI_IN010000UK13/acknowledgement[@type='Acknowledgement' and @typeCode='AE']/acknowledgementDetail[@type='AcknowledgementDetail' and @typeCode='ER']/code[@code='18']".replace("/", XML_NAMESPACE));
         XmlAssert.assertThat(requestJournal.get(0).getPayload())
             .hasXPath("/MCCI_IN010000UK13/ControlActEvent/reason/justifyingDetectedIssueEvent/code[@code='18']".replace("/", XML_NAMESPACE));
+    }
+
+    @Test
+    public void sendThroughMedicusMeasurementsBugASR() throws IOException, NamingException, JMSException {
+        String conversationId = UUID.randomUUID().toString();
+        String ehrExtractRequest = buildEhrExtractRequest(conversationId, NHS_NUMBER_MEDICUS_TEST_UNITS_OF_MEASUREMENT_ASR, FROM_ODS_CODE_1);
+        MessageQueue.sendToMhsInboundQueue(ehrExtractRequest);
     }
 
     @Test

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
@@ -41,6 +41,7 @@ import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.MedicationStatementTemplateParameters;
 import uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils;
 import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
+import uk.nhs.adaptors.gp2gp.ehr.utils.UnitsOfTimeMappingUtils;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Component
@@ -189,7 +190,9 @@ public class MedicationStatementMapper {
         if (medicationRequest.hasDispenseRequest() && medicationRequest.getDispenseRequest().hasExpectedSupplyDuration()) {
             return String.format(EXPECTED_SUPPLY_DURATION,
                 medicationRequest.getDispenseRequest().getExpectedSupplyDuration().getValue().toString(),
-                medicationRequest.getDispenseRequest().getExpectedSupplyDuration().getUnit());
+                UnitsOfTimeMappingUtils.mapCodeToDisplayValue(
+                    medicationRequest.getDispenseRequest().getExpectedSupplyDuration().getCode())
+            );
         }
         return StringUtils.EMPTY;
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapper.java
@@ -60,7 +60,7 @@ public final class ObservationValueQuantityMapper {
     private static String prepareQuantityValueWithoutComparator(Quantity valueQuantity) {
         BigDecimal value = valueQuantity.getValue();
         if (valueQuantity.hasSystem() && valueQuantity.getSystem().equals(UNITS_OF_MEASURE_SYSTEM)) {
-            return String.format(NO_COMPARATOR_VALUE_TEMPLATE, value, valueQuantity.getCode());
+            return String.format(NO_COMPARATOR_VALUE_TEMPLATE, value, valueQuantity.getUnit());
         } else {
             return String.format(NO_COMPARATOR_NO_SYSTEM_VALUE_TEMPLATE, value, value, prepareUnit(valueQuantity));
         }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/UnitsOfTimeMappingUtils.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/UnitsOfTimeMappingUtils.java
@@ -1,0 +1,19 @@
+package uk.nhs.adaptors.gp2gp.ehr.utils;
+
+import java.util.Map;
+
+public class UnitsOfTimeMappingUtils {
+    private static final Map<String, String> UNITS_OF_TIME = Map.of(
+        "s", "seconds",
+        "min", "minute",
+        "h", "hours",
+        "d", "days",
+        "wk", "weeks",
+        "mo", "months",
+        "a", "years"
+    );
+
+    public static String mapCodeToDisplayValue(String code) {
+        return UNITS_OF_TIME.get(code);
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapperTest.java
@@ -80,6 +80,10 @@ public class ObservationValueQuantityMapperTest {
         + "example-observation-resource-with-quantity-16.json";
     private static final String OUTPUT_XML_WITH_NO_SYSTEM_NO_UNIT_AND_EQUAL_GREATER_COMPARATOR = TEST_FILES_DIRECTORY
         + "expected-output-quantity-16.xml";
+    private static final String INPUT_JSON_WITH_UNIT_OF_MEASURE_SYSTEM_NO_COMPARATOR_NO_CODE = TEST_FILES_DIRECTORY
+        + "example-observation-resource-with-quantity-17.json";
+    private static final String OUTPUT_JSON_WITH_UNIT_OF_MEASURE_SYSTEM_NO_COMPARATOR_NO_CODE = TEST_FILES_DIRECTORY
+        + "expected-output-quantity-17.xml";
 
     @ParameterizedTest
     @MethodSource("testFilePaths")
@@ -126,7 +130,9 @@ public class ObservationValueQuantityMapperTest {
             Arguments.of(INPUT_JSON_WITH_NO_SYSTEM_NO_UNIT_AND_GREATER_COMPARATOR,
                 OUTPUT_XML_WITH_NO_SYSTEM_NO_UNIT_AND_GREATER_COMPARATOR),
             Arguments.of(INPUT_JSON_WITH_NO_SYSTEM_NO_UNIT_AND_EQUAL_GREATER_COMPARATOR,
-                OUTPUT_XML_WITH_NO_SYSTEM_NO_UNIT_AND_EQUAL_GREATER_COMPARATOR)
+                OUTPUT_XML_WITH_NO_SYSTEM_NO_UNIT_AND_EQUAL_GREATER_COMPARATOR),
+            Arguments.of(INPUT_JSON_WITH_UNIT_OF_MEASURE_SYSTEM_NO_COMPARATOR_NO_CODE,
+                OUTPUT_JSON_WITH_UNIT_OF_MEASURE_SYSTEM_NO_COMPARATOR_NO_CODE)
         );
     }
 }

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-acute-prescription.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-acute-prescription.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-default-status-reason-code.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-default-status-reason-code.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-optional-fields.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-optional-fields.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription-no-value.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription-no-value.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-repeat-prescription.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-start-period-only.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-start-period-only.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-dispense-quantity-text.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-dispense-quantity-text.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-text.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-text.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-value.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-dispense-quantity-value.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-quantity-quantity-text.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-quantity-quantity-text.xml
@@ -31,7 +31,7 @@
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 day Notes: Example note text 1 Example note text 2 Example note text 3</text>
+                        <text>Patient Instruction: Take in morning Expected Supply Duration: 28 days Notes: Example note text 1 Example note text 2 Example note text 3</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>

--- a/service/src/test/resources/ehr/mapper/observation/quantity/example-observation-resource-with-quantity-17.json
+++ b/service/src/test/resources/ehr/mapper/observation/quantity/example-observation-resource-with-quantity-17.json
@@ -1,0 +1,46 @@
+{
+    "resourceType": "Observation",
+    "id": "491ef27b-28d9-11eb-adc1-f07859c314bd",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "491ef27b-28d9-11eb-adc1-f07859c314bd"
+        }
+    ],
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "248333004",
+                "display": "Standing height",
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                        "extension": [
+                            {
+                                "url": "descriptionId",
+                                "valueId": "370729019"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+    },
+    "effectiveDateTime": "2022-06-30T10:20:00+01:00",
+    "issued": "2022-09-16T23:29:31+01:00",
+    "valueQuantity": {
+        "value": 186,
+        "unit": "cm",
+        "system": "http://unitsofmeasure.org"
+    }
+}

--- a/service/src/test/resources/ehr/mapper/observation/quantity/expected-output-quantity-1.xml
+++ b/service/src/test/resources/ehr/mapper/observation/quantity/expected-output-quantity-1.xml
@@ -1,1 +1,1 @@
-<value xsi:type="PQ" value="37.1" unit="Cel"/>
+<value xsi:type="PQ" value="37.1" unit="C"/>

--- a/service/src/test/resources/ehr/mapper/observation/quantity/expected-output-quantity-17.xml
+++ b/service/src/test/resources/ehr/mapper/observation/quantity/expected-output-quantity-17.xml
@@ -1,0 +1,1 @@
+<value xsi:type="PQ" value="186" unit="cm"/>

--- a/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
@@ -683,7 +683,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -755,7 +755,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -827,7 +827,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -899,7 +899,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -971,7 +971,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1043,7 +1043,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1115,7 +1115,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1187,7 +1187,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1259,7 +1259,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1331,7 +1331,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1403,7 +1403,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1475,7 +1475,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1547,7 +1547,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1619,7 +1619,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1691,7 +1691,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1763,7 +1763,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1835,7 +1835,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1907,7 +1907,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -1979,7 +1979,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2051,7 +2051,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2123,7 +2123,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2195,7 +2195,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2267,7 +2267,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2339,7 +2339,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2411,7 +2411,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2483,7 +2483,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2555,7 +2555,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2627,7 +2627,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2699,7 +2699,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2771,7 +2771,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2843,7 +2843,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2915,7 +2915,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -2987,7 +2987,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3059,7 +3059,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3130,7 +3130,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1825 day</text>
+                        <text>Expected Supply Duration: 1825 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -3202,7 +3202,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1825 day</text>
+                        <text>Expected Supply Duration: 1825 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3273,7 +3273,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -3345,7 +3345,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3417,7 +3417,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3489,7 +3489,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3561,7 +3561,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3633,7 +3633,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3705,7 +3705,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3777,7 +3777,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3849,7 +3849,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3921,7 +3921,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -3993,7 +3993,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4065,7 +4065,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4137,7 +4137,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4209,7 +4209,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4281,7 +4281,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4353,7 +4353,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4424,7 +4424,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -4496,7 +4496,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4567,7 +4567,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1 day</text>
+                        <text>Expected Supply Duration: 1 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -4639,7 +4639,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1 day</text>
+                        <text>Expected Supply Duration: 1 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4710,7 +4710,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -4781,7 +4781,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1 day</text>
+                        <text>Expected Supply Duration: 1 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -4852,7 +4852,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -4924,7 +4924,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -4996,7 +4996,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5068,7 +5068,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5140,7 +5140,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5212,7 +5212,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5284,7 +5284,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5356,7 +5356,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5428,7 +5428,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5500,7 +5500,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5572,7 +5572,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5644,7 +5644,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5715,7 +5715,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -5787,7 +5787,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5859,7 +5859,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -5931,7 +5931,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -6003,7 +6003,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -6075,7 +6075,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -6146,7 +6146,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1825 day</text>
+                        <text>Expected Supply Duration: 1825 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -6217,7 +6217,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1825 day</text>
+                        <text>Expected Supply Duration: 1825 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -6289,7 +6289,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 1825 day</text>
+                        <text>Expected Supply Duration: 1825 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -6360,7 +6360,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -6432,7 +6432,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>
@@ -6503,7 +6503,7 @@ The line below contains special characters...
                 </quantity>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyAuthorise>
@@ -6575,7 +6575,7 @@ The line below contains special characters...
 </inFulfillmentOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation>
-                        <text>Expected Supply Duration: 28 day</text>
+                        <text>Expected Supply Duration: 28 days</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyPrescribe>


### PR DESCRIPTION
“The unit of measurement is converted to "null" for
        (a) Standing height 186cm
        (b) Blood pressure 129/87 mmHg
        (c) Smoking free weeks: 12 weeks“

Comparing the attached GPC output and GP2GP output, no value units have been mapped in the GP2GP HL7 payload.

Examples:


        (a) Standing height 186cm
        (b) Blood pressure 129/87 mmHg
        (c) Smoking free weeks: 12 weeks


GP2GP Output:

      <value xsi:type="PQ" value="186" unit="null"/>

Action: Fix unit to include the given value in from the GPC output.

**NOTE: The unit of time for `MedicationRequest.dispenceRequest.expectedSupplyDuration`  was also being mapped to `null` in the Medicus example. So I've addressed it as part of this ticket. **