### PR TITLE
NIAD-2398 Mapping bug: practitioner missing

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AgentPersonMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AgentPersonMapper.java
@@ -1,7 +1,6 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AgentPersonMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AgentPersonMapper.java
@@ -29,10 +29,8 @@ public class AgentPersonMapper {
 
     public String mapAgentPerson(AgentDirectory.AgentKey agentKey, String agentDirectoryId) {
         var builder = PractitionerAgentPersonMapperParameters
-                .builder()
-                .agentId(agentDirectoryId);
-
-        AtomicReference<String> tempNameFromText = new AtomicReference<>("");
+            .builder()
+            .agentId(agentDirectoryId);
 
         if (agentKey.getPractitionerReference() != null) {
             messageContext.getInputBundleHolder()
@@ -51,8 +49,9 @@ public class AgentPersonMapper {
                         practitionerFamily.ifPresent(builder::practitionerFamilyName);
 
                         if (practitionerGiven.isEmpty() && practitionerFamily.isEmpty()) {
-                            practitionerUnstructuredName.ifPresentOrElse
-                                (builder::practitionerUnstructuredName, () -> builder.practitionerFamilyName(UNKNOWN));
+                            practitionerUnstructuredName.ifPresentOrElse(
+                                builder::practitionerUnstructuredName, () -> builder.practitionerFamilyName(UNKNOWN)
+                            );
                         }
                     });
 
@@ -80,7 +79,7 @@ public class AgentPersonMapper {
     }
 
     private Optional<String> buildPractitionerUnstructuredName(Practitioner practitioner) {
-        if(practitioner.hasName() && practitioner.getNameFirstRep().hasText()) {
+        if (practitioner.hasName() && practitioner.getNameFirstRep().hasText()) {
             return Optional.of(practitioner.getNameFirstRep().getText());
         }
         return Optional.empty();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/PractitionerAgentPersonMapperParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/PractitionerAgentPersonMapperParameters.java
@@ -15,4 +15,5 @@ public class PractitionerAgentPersonMapperParameters {
     private String practitionerFamilyName;
     private String organization;
     private boolean practitioner;
+    private String practitionerUnstructuredName;
 }

--- a/service/src/main/resources/templates/ehr_agent_person_template.mustache
+++ b/service/src/main/resources/templates/ehr_agent_person_template.mustache
@@ -6,6 +6,10 @@
         </code>
         {{#practitioner}}
         <agentPerson classCode="PSN" determinerCode="INSTANCE">
+            {{#practitionerUnstructuredName}}
+            <name>{{practitionerUnstructuredName}}</name>
+            {{/practitionerUnstructuredName}}
+            {{^practitionerUnstructuredName}}
             <name>
                 {{#practitionerPrefix}}
                 <prefix>{{practitionerPrefix}}</prefix>
@@ -17,11 +21,12 @@
                 <family>{{practitionerFamilyName}}</family>
                 {{/practitionerFamilyName}}
             </name>
+            {{/practitionerUnstructuredName}}
         </agentPerson>
         {{/practitioner}}
         {{#organization}}
         <representedOrganization classCode="ORG" determinerCode="INSTANCE">
-{{{organization}}}
+            {{{organization}}}
         </representedOrganization>
         {{/organization}}
     </Agent>

--- a/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-full-name-and-unstructured.json
+++ b/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-full-name-and-unstructured.json
@@ -1,0 +1,24 @@
+{
+    "resourceType": "Practitioner",
+    "id": "6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+    "meta": {
+        "versionId": "4749697187075864793",
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+        ]
+    },
+    "name": [
+        {
+            "use": "official",
+            "family": "McAvenue",
+            "given": [
+                "David"
+            ],
+            "prefix": [
+                "Dr"
+            ],
+            "text": "David McAvenue"
+        }
+    ],
+    "gender": "male"
+}

--- a/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-full-name-and-unstructured.xml
+++ b/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-full-name-and-unstructured.xml
@@ -1,0 +1,15 @@
+<part typeCode="PART">
+    <Agent classCode="AGNT">
+        <id root="6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"/>
+        <code nullFlavor="UNK">
+            <originalText>Unknown</originalText>
+        </code>
+        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+            <name>
+                <prefix>Dr</prefix>
+                <given>David</given>
+                <family>McAvenue</family>
+            </name>
+        </agentPerson>
+    </Agent>
+</part>

--- a/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-unstructured-only.json
+++ b/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-unstructured-only.json
@@ -1,0 +1,17 @@
+{
+    "resourceType": "Practitioner",
+    "id": "6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+    "meta": {
+        "versionId": "cf7c7d18eb75d97ef4893b516f40c58c",
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+        ]
+    },
+    "active": true,
+    "name": [
+        {
+            "use": "official",
+            "text": "Paula Allen"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-unstructured-only.xml
+++ b/service/src/test/resources/ehr/mapper/practitioner/practitioner-only/practitioner-unstructured-only.xml
@@ -1,0 +1,11 @@
+<part typeCode="PART">
+    <Agent classCode="AGNT">
+        <id root="6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"/>
+        <code nullFlavor="UNK">
+            <originalText>Unknown</originalText>
+        </code>
+        <agentPerson classCode="PSN" determinerCode="INSTANCE">
+            <name>Paula Allen</name>
+        </agentPerson>
+    </Agent>
+</part>


### PR DESCRIPTION
During the investigation for this ticket, it was found practitioners with an unstructured name, as below;
```
"name": [
            {
                "use": "official",
                "text": "Nick Matthews"
            }
        ]
```
were mapped to the EHR agent element with an unknown name:
```
<name>
    <family>Unknown</family>
</name>
```
The mapping has been altered, so that if the `family` and `given` name elements are not present, the `text` element will be used. Therefore, the example above will be mapped to an unstructured name element, as follows:
```
 <name>Nick Matthews</name>
```