### PR TITLE
NIAD-2421 Prescribed Elsewhere has the wrong SNOMED code.

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -36,6 +36,13 @@ public class CodeableConceptCdMapper {
     private static final String PROBLEM_DISPLAY_NAME = "Problem";
     private static final String ACTIVE_CLINICAL_STATUS = "active";
     private static final String RESOLVED_CLINICAL_STATUS = "resolved";
+    private static final String PRESCRIBING_AGENCY_GP_PRACTICE_CODE = "prescribed-at-gp-practice";
+    private static final String PRESCRIBING_AGENCY_PREVIOUS_PRACTICE_CODE = "prescribed-by-previous-practice";
+    private static final String PRESCRIBING_AGENCY_ANOTHER_ORGANISATION_CODE = "prescribed-by-another-organisation";
+    private static final String EHR_SUPPLY_TYPE_NHS_PRESCRIPTION_CODE = "394823007";
+    private static final String EHR_SUPPLY_TYPE_NHS_PRESCRIPTION_DISPLAY = "NHS Prescription";
+    private static final String EHR_SUPPLY_TYPE_ANOTHER_ORGANISATION_CODE = "394828003";
+    private static final String EHR_SUPPLY_TYPE_ANOTHER_ORGANISATION_DISPLAY = "Prescription by another organisation";
 
     public String mapCodeableConceptToCd(CodeableConcept codeableConcept) {
         var builder = CodeableConceptCdTemplateParameters.builder();
@@ -157,14 +164,14 @@ public class CodeableConceptCdMapper {
         }
 
         switch (prescribingAgency.orElseThrow().getCode()) {
-            case "prescribed-at-gp-practice":
-            case "prescribed-by-previous-practice":
-                code = "394823007";
-                displayText = "NHS Prescription";
+            case PRESCRIBING_AGENCY_GP_PRACTICE_CODE:
+            case PRESCRIBING_AGENCY_PREVIOUS_PRACTICE_CODE:
+                code = EHR_SUPPLY_TYPE_NHS_PRESCRIPTION_CODE;
+                displayText = EHR_SUPPLY_TYPE_NHS_PRESCRIPTION_DISPLAY;
                 break;
-            case "prescribed-by-another-organisation":
-                code = "394828003";
-                displayText = "Prescription by another organisation";
+            case PRESCRIBING_AGENCY_ANOTHER_ORGANISATION_CODE:
+                code = EHR_SUPPLY_TYPE_ANOTHER_ORGANISATION_CODE;
+                displayText = EHR_SUPPLY_TYPE_ANOTHER_ORGANISATION_DISPLAY;
                 break;
             default:
                 return Optional.empty();
@@ -176,9 +183,8 @@ public class CodeableConceptCdMapper {
             .mainDisplayName(displayText);
 
         return Optional.of(TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build()));
-
     }
-    
+
     private Optional<Coding> findPrescribingAgency(CodeableConcept codeableConcept) {
         return codeableConcept.getCoding()
             .stream()
@@ -271,7 +277,7 @@ public class CodeableConceptCdMapper {
     private boolean isSnomed(Coding coding) {
         return coding.hasSystem() && coding.getSystem().equals(SNOMED_SYSTEM);
     }
-    
+
     private boolean isPrescribingAgency(Coding coding) {
         return coding.hasSystem() && coding.getSystem().equals(CARE_CONNECT_PRESCRIBING_AGENCY_SYSTEM);
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementExtractor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementExtractor.java
@@ -44,6 +44,7 @@ public class MedicationStatementExtractor {
     private static final String AVAILABILITY_TIME_VALUE_TEMPLATE = "<availabilityTime value=\"%s\"/>";
     private static final String DEFAULT_QUANTITY_TEXT = "Unk UoM";
     private static final String NO_INFO_AVAILABLE = "No information available";
+    private static final String PRESCRIBING_AGENCY_EXTENSION_URL = "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1";
 
     public static String extractDispenseRequestQuantityText(MedicationRequest medicationRequest) {
         return medicationRequest.getDispenseRequest()
@@ -172,25 +173,26 @@ public class MedicationStatementExtractor {
         return TemplateUtils.fillTemplate(IN_FULFILMENT_OF_TEMPLATE, inFulfilmentOfTemplateParameters);
     }
 
-    public static Optional<CodeableConcept> extractEhrSupplyTypeCodeableConcept(MedicationRequest medicationRequest, MessageContext messageContext) {
+    public static Optional<CodeableConcept> extractEhrSupplyTypeCodeableConcept(MedicationRequest medicationRequest,
+        MessageContext messageContext) {
         var medicationStatements = messageContext.getInputBundleHolder().getResourcesOfType(MedicationStatement.class);
-        var medicationRequestReference = medicationRequest.getId();
 
         var medicationStatement = medicationStatements.stream()
             .filter(resource -> resource.getResourceType().equals(ResourceType.MedicationStatement))
             .map(MedicationStatement.class::cast)
             .filter(MedicationStatement::hasBasedOn)
             .filter(statement -> statement.getBasedOn().stream()
-                .anyMatch(reference -> reference.getReference().equals(medicationRequestReference))
+                .anyMatch(reference -> reference.getReference().equals(medicationRequest.getId()))
             )
             .findFirst();
 
-         return medicationStatement.flatMap(
+        return medicationStatement.flatMap(
             statement -> statement.getExtension().stream()
-                .filter(extension -> extension.getUrlElement().getValue().equals("https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1"))
+                .filter(Extension::hasUrl)
+                .filter(extension -> extension.getUrlElement().getValue().equals(PRESCRIBING_AGENCY_EXTENSION_URL))
+                .filter(Extension::hasValue)
                 .map(extension -> (CodeableConcept) extension.getValue())
                 .findFirst()
         );
-
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
@@ -303,7 +303,7 @@ public class MedicationStatementMapper {
     }
 
     private Optional<String> buildEhrSupplyTypeCode(MedicationRequest medicationRequest) {
-        var ehrSupplyTypeCodeableConcept = extractEhrSupplyTypeCodeableConcept(medicationRequest, messageContext);
-        return ehrSupplyTypeCodeableConcept.flatMap(codeableConceptCdMapper::mapCodeableConceptToCdForEhrSupplyType);
+        return extractEhrSupplyTypeCodeableConcept(medicationRequest, messageContext)
+            .flatMap(codeableConceptCdMapper::mapCodeableConceptToCdForEhrSupplyType);
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
@@ -1,11 +1,11 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityTextFromQuantity;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractIdFromPlanMedicationRequestReference;
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityText;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractRepeatValue;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityTextFromQuantity;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractEhrSupplyTypeCodeableConcept;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractIdFromPlanMedicationRequestReference;
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractPrescriptionTypeCode;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractRepeatValue;
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedAvailabilityTime;
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedCode;
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedText;
@@ -20,7 +20,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Annotation;
 import org.hl7.fhir.dstu3.model.Medication;
@@ -35,6 +34,7 @@ import org.springframework.stereotype.Component;
 
 import com.github.mustachejava.Mustache;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
@@ -95,8 +95,9 @@ public class MedicationStatementMapper {
         var ehrSupplyDiscontinueReasonText = buildStatusReasonStoppedText(medicationRequest);
         var basedOn = buildBasedOn(medicationRequest);
         var participant = buildParticipant(medicationRequest);
+        var ehrSupplyTypeCode = buildEhrSupplyTypeCode(medicationRequest);
 
-        var medicationStatementTemplateParameters = MedicationStatementTemplateParameters.builder()
+        var medicationStatementTemplateParametersBuilder = MedicationStatementTemplateParameters.builder()
             .medicationStatementId(medicationStatementId)
             .statusCode(statusCode)
             .effectiveTime(effectiveTime)
@@ -114,13 +115,14 @@ public class MedicationStatementMapper {
             .ehrSupplyDiscontinueAvailabilityTime(ehrSupplyDiscontinueAvailabilityTime)
             .ehrSupplyDiscontinueReasonText(ehrSupplyDiscontinueReasonText)
             .basedOn(basedOn)
-            .participant(participant)
-            .build();
+            .participant(participant);
+
+        ehrSupplyTypeCode.ifPresent(medicationStatementTemplateParametersBuilder::ehrSupplyTypeCode);
 
         final var template = DISPLAY_TO_TEMPLATE_MAPPER.apply(medicationRequest.getIntent().getDisplay())
             .orElseThrow(() -> new EhrMapperException("Could not resolve Medication Request intent"));
 
-        return TemplateUtils.fillTemplate(template, medicationStatementTemplateParameters);
+        return TemplateUtils.fillTemplate(template, medicationStatementTemplateParametersBuilder.build());
     }
 
     private String buildStatusCode(MedicationRequest medicationRequest) {
@@ -298,5 +300,10 @@ public class MedicationStatementMapper {
 
     private static Predicate<Reference> buildPredicateReferenceIsA(@NonNull ResourceType type) {
         return reference -> type.name().equals(reference.getReferenceElement().getResourceType());
+    }
+
+    private Optional<String> buildEhrSupplyTypeCode(MedicationRequest medicationRequest) {
+        var ehrSupplyTypeCodeableConcept = extractEhrSupplyTypeCodeableConcept(medicationRequest, messageContext);
+        return ehrSupplyTypeCodeableConcept.flatMap(codeableConceptCdMapper::mapCodeableConceptToCdForEhrSupplyType);
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/MedicationStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/MedicationStatementTemplateParameters.java
@@ -26,4 +26,5 @@ public class MedicationStatementTemplateParameters {
     private String ehrSupplyDiscontinueReasonText;
     private String basedOn;
     private String participant;
+    private String ehrSupplyTypeCode;
 }

--- a/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
@@ -18,7 +18,12 @@
         <component typeCode="COMP">
             <ehrSupplyAuthorise>
                 <id root="{{ehrSupplyId}}"/>
+                {{#ehrSupplyTypeCode}}
+                {{{ehrSupplyTypeCode}}}
+                {{/ehrSupplyTypeCode}}
+                {{^ehrSupplyTypeCode}}
                 <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                {{/ehrSupplyTypeCode}}
                 <statusCode code="{{statusCode}}"/>
                 {{#effectiveTime}}
                     <effectiveTime>

--- a/service/src/main/resources/templates/ehr_medication_statement_prescribe_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_prescribe_template.mustache
@@ -18,7 +18,12 @@
         <component typeCode="COMP">
             <ehrSupplyPrescribe>
                 <id root="{{ehrSupplyId}}"/>
+                {{#ehrSupplyTypeCode}}
+                {{{ehrSupplyTypeCode}}}
+                {{/ehrSupplyTypeCode}}
+                {{^ehrSupplyTypeCode}}
                 <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                {{/ehrSupplyTypeCode}}
                 <statusCode code="{{statusCode}}"/>
                 {{{availabilityTime}}}
                 <quantity value="{{quantityValue}}" unit="1">

--- a/service/src/test/resources/ehr/mapper/medication_request/fhir-bundle-with-medication-statements.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/fhir-bundle-with-medication-statements.json
@@ -1,0 +1,1002 @@
+{
+    "resourceType": "Bundle",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "00d756ae-360d-11ed-95ee-060b232f1aa2",
+                "meta": {
+                    "versionId": "b054cee05d5843b5d9e856b10c56d79a",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+                        "extension": [
+                            {
+                                "url": "registrationPeriod",
+                                "valuePeriod": {
+                                    "start": "2000-06-29"
+                                }
+                            },
+                            {
+                                "url": "registrationType",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                                            "code": "R",
+                                            "display": "Regular"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                                            "code": "01",
+                                            "display": "Number present and verified"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "9693142837"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Watson",
+                        "prefix": [
+                            "Mr"
+                        ],
+                        "given": [
+                            "Sam"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "2020-12-22",
+                "address": [
+                    {
+                        "use": "home",
+                        "line": [
+                            "126 GREEN DRAGON LANE",
+                            "LONDON"
+                        ],
+                        "postalCode": "N21 1HA",
+                        "country": "GBR"
+                    }
+                ],
+                "managingOrganization": {
+                    "reference": "Organization/F85003"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "4a18bd73-28d9-11eb-adc1-213bc7ad69f8",
+                "meta": {
+                    "versionId": "cf7c7d18eb75d97ef4893b516f40c58c",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "text": "Paula Allen"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "F85003",
+                "meta": {
+                    "versionId": "46b094770b261cb692f88dd406ba5c31",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                        "value": "F85003"
+                    }
+                ],
+                "active": true,
+                "name": "Riley House GP Practice",
+                "address": [
+                    {
+                        "use": "work",
+                        "line": [
+                            "101 Yvonne Falls"
+                        ],
+                        "city": "West Carey",
+                        "district": "Norfolk",
+                        "postalCode": "MK3 7SA",
+                        "country": "GBR"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "+441273749184",
+                        "use": "work"
+                    },
+                    {
+                        "system": "fax",
+                        "value": "+441455338473",
+                        "use": "work"
+                    },
+                    {
+                        "system": "email",
+                        "value": "bakers.hill@medicus.health",
+                        "use": "work"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Location",
+                "id": "c1073d6b-28d9-11eb-adc1-2a09fc8b15ed",
+                "meta": {
+                    "versionId": "337ee2cb549a0c54a2819eaf9ddc9e7a",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Location-1"
+                    ]
+                },
+                "status": "active",
+                "name": "Andover Site",
+                "address": [
+                    {
+                        "use": "work",
+                        "line": [
+                            "872 Melisa Spurs"
+                        ],
+                        "city": "Legrosberg",
+                        "district": "Cornwall",
+                        "postalCode": "W5 9TG",
+                        "country": "GBR"
+                    }
+                ],
+                "managingOrganization": {
+                    "reference": "Organization/F85003"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1332aa9c-28d6-11eb-adc1-0242ac120002",
+                "meta": {
+                    "versionId": "d638bbaf8a63b7bfd23de016e0ecbb65",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Lincoln",
+                        "prefix": [
+                            "Dr"
+                        ],
+                        "given": [
+                            "Lara",
+                            "Lona"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "ms-e95ecc90-43af-11ed-8306-0a0bbb679524",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "ms-e95ecc90-43af-11ed-8306-0a0bbb679524"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-by-another-organisation",
+                                    "display": "Prescribed by another organisation"
+                                }
+                            ],
+                            "text": "Over the counter medication"
+                        }
+                    }
+                ],
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                },
+                "status": "active",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-e95ecc90-43af-11ed-8306-0a0bbb679524"
+                    }
+                ],
+                "medicationReference": {
+                    "reference": "Medication/412556009"
+                },
+                "effectivePeriod": {
+                    "start": "2022-10-04"
+                },
+                "dateAsserted": "2022-10-04",
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "0.1ml once per day"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "mr-e95ecc90-43af-11ed-8306-0a0bbb679524",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "mr-e95ecc90-43af-11ed-8306-0a0bbb679524"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "text": "No information available"
+                        }
+                    }
+                ],
+                "status": "active",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/412556009"
+                },
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "authoredOn": "2022-10-04",
+                "recorder": {
+                    "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "0.1ml once per day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2022-10-04"
+                    }
+                },
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "412556009",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "412556009",
+                            "display": "Co-codamol"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "ms-0614dac8-43b0-11ed-bf45-0a0bbb679524",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "ms-0614dac8-43b0-11ed-bf45-0a0bbb679524"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2022-10-04"
+                    }
+                ],
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                },
+                "status": "completed",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-0614dac8-43b0-11ed-bf45-0a0bbb679524"
+                    }
+                ],
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "effectivePeriod": {
+                    "start": "2022-10-04",
+                    "end": "2022-11-01"
+                },
+                "dateAsserted": "2022-10-04",
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "mr-0614dac8-43b0-11ed-bf45-0a0bbb679524",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "mr-0614dac8-43b0-11ed-bf45-0a0bbb679524"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "authoredOn": "2022-10-04",
+                "recorder": {
+                    "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Organization/F85003"
+                    }
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2022-10-04",
+                        "end": "2022-11-01"
+                    },
+                    "quantity": {
+                        "value": 1,
+                        "unit": "dose"
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                },
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "ms-a231e73b-e631-4c87-82c2-e2e3d45d6b84",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "ms-a231e73b-e631-4c87-82c2-e2e3d45d6b84"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-by-previous-practice",
+                                    "display": "Prescribed by previous practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2022-10-04"
+                    }
+                ],
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                },
+                "status": "completed",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-4c816c87-09b5-4bec-bae4-e81855758da7"
+                    }
+                ],
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "effectivePeriod": {
+                    "start": "2022-10-04",
+                    "end": "2022-11-01"
+                },
+                "dateAsserted": "2022-10-04",
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "mr-4c816c87-09b5-4bec-bae4-e81855758da7",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "mr-4c816c87-09b5-4bec-bae4-e81855758da7"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "authoredOn": "2022-10-04",
+                "recorder": {
+                    "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Organization/F85003"
+                    }
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2022-10-04",
+                        "end": "2022-11-01"
+                    },
+                    "quantity": {
+                        "value": 1,
+                        "unit": "dose"
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                },
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "ms-cff96f1d-0abc-47f1-8549-5ebb4a2c22a9",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "ms-cff96f1d-0abc-47f1-8549-5ebb4a2c22a9"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": []
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2022-10-04"
+                    }
+                ],
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                },
+                "status": "completed",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-4f8728a6-e2d1-49e6-8f29-a6bdb8781b65"
+                    }
+                ],
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "effectivePeriod": {
+                    "start": "2022-10-04",
+                    "end": "2022-11-01"
+                },
+                "dateAsserted": "2022-10-04",
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "mr-4f8728a6-e2d1-49e6-8f29-a6bdb8781b65",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "mr-4c816c87-09b5-4bec-bae4-e81855758da7"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "authoredOn": "2022-10-04",
+                "recorder": {
+                    "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Organization/F85003"
+                    }
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2022-10-04",
+                        "end": "2022-11-01"
+                    },
+                    "quantity": {
+                        "value": 1,
+                        "unit": "dose"
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                },
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "ms-f4afb1d5-d6d1-431f-9dc9-15fc6c363ab6",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "ms-f4afb1d5-d6d1-431f-9dc9-15fc6c363ab6"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2022-10-04"
+                    }
+                ],
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                },
+                "status": "completed",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-97efbccf-fb40-4f6d-b40a-bbdcc18ba9f0"
+                    }
+                ],
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "effectivePeriod": {
+                    "start": "2022-10-04",
+                    "end": "2022-11-01"
+                },
+                "dateAsserted": "2022-10-04",
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "mr-97efbccf-fb40-4f6d-b40a-bbdcc18ba9f0",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "mr-97efbccf-fb40-4f6d-b40a-bbdcc18ba9f0"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/26148711000001101"
+                },
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "authoredOn": "2022-10-04",
+                "recorder": {
+                    "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Organization/F85003"
+                    }
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "One puff as needed. Max 10 doses per day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2022-10-04",
+                        "end": "2022-11-01"
+                    },
+                    "quantity": {
+                        "value": 1,
+                        "unit": "dose"
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                },
+                "context": {
+                    "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "26148711000001101",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "26148711000001101",
+                            "display": "Beclometasone 100micrograms/dose / Formoterol 6micrograms/dose dry powder inhaler"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "e61ec0cc-43ae-11ed-ba7c-0a0bbb679524",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "325861000000105",
+                                "display": "Face to face consultation",
+                                "extension": [
+                                    {
+                                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                        "extension": [
+                                            {
+                                                "url": "descriptionId",
+                                                "valueId": "600731000000118"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                                        "code": "PPRF",
+                                        "display": "Primary Performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                                        "code": "PART",
+                                        "display": "Participant"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/4a18bd73-28d9-11eb-adc1-213bc7ad69f8"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                                        "code": "PART",
+                                        "display": "Participant"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "display": "translator"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "Recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2022-10-04T07:36:00+01:00"
+                },
+                "location": [
+                    {
+                        "location": {
+                            "reference": "Location/c1073d6b-28d9-11eb-adc1-2a09fc8b15ed"
+                        }
+                    }
+                ],
+                "serviceProvider": {
+                    "reference": "Organization/F85003"
+                }
+            }
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-request-empty-prescribing-agency-coding-array.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-request-empty-prescribing-agency-coding-array.json
@@ -1,0 +1,69 @@
+{
+    "resourceType": "MedicationRequest",
+    "id": "mr-4f8728a6-e2d1-49e6-8f29-a6bdb8781b65",
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "mr-4c816c87-09b5-4bec-bae4-e81855758da7"
+        }
+    ],
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                        "code": "acute",
+                        "display": "Acute"
+                    }
+                ]
+            }
+        }
+    ],
+    "status": "completed",
+    "intent": "plan",
+    "medicationReference": {
+        "reference": "Medication/26148711000001101"
+    },
+    "subject": {
+        "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+    },
+    "authoredOn": "2022-10-04",
+    "recorder": {
+        "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+    },
+    "requester": {
+        "agent": {
+            "reference": "Organization/F85003"
+        }
+    },
+    "dosageInstruction": [
+        {
+            "text": "One puff as needed. Max 10 doses per day"
+        }
+    ],
+    "dispenseRequest": {
+        "validityPeriod": {
+            "start": "2022-10-04",
+            "end": "2022-11-01"
+        },
+        "quantity": {
+            "value": 1,
+            "unit": "dose"
+        },
+        "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+        }
+    },
+    "context": {
+        "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+    }
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-request-missing-prescribing-agency-codeable-concept.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-request-missing-prescribing-agency-codeable-concept.json
@@ -1,0 +1,69 @@
+{
+    "resourceType": "MedicationRequest",
+    "id": "mr-97efbccf-fb40-4f6d-b40a-bbdcc18ba9f0",
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "mr-97efbccf-fb40-4f6d-b40a-bbdcc18ba9f0"
+        }
+    ],
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                        "code": "acute",
+                        "display": "Acute"
+                    }
+                ]
+            }
+        }
+    ],
+    "status": "completed",
+    "intent": "plan",
+    "medicationReference": {
+        "reference": "Medication/26148711000001101"
+    },
+    "subject": {
+        "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+    },
+    "authoredOn": "2022-10-04",
+    "recorder": {
+        "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+    },
+    "requester": {
+        "agent": {
+            "reference": "Organization/F85003"
+        }
+    },
+    "dosageInstruction": [
+        {
+            "text": "One puff as needed. Max 10 doses per day"
+        }
+    ],
+    "dispenseRequest": {
+        "validityPeriod": {
+            "start": "2022-10-04",
+            "end": "2022-11-01"
+        },
+        "quantity": {
+            "value": 1,
+            "unit": "dose"
+        },
+        "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+        }
+    },
+    "context": {
+        "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+    }
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-request-prescribed-by-another-organisation.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-request-prescribed-by-another-organisation.json
@@ -1,0 +1,48 @@
+{
+    "resourceType": "MedicationRequest",
+    "id": "mr-e95ecc90-43af-11ed-8306-0a0bbb679524",
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "mr-e95ecc90-43af-11ed-8306-0a0bbb679524"
+        }
+    ],
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "text": "No information available"
+            }
+        }
+    ],
+    "status": "active",
+    "intent": "plan",
+    "medicationReference": {
+        "reference": "Medication/412556009"
+    },
+    "subject": {
+        "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+    },
+    "authoredOn": "2022-10-04",
+    "recorder": {
+        "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+    },
+    "dosageInstruction": [
+        {
+            "text": "0.1ml once per day"
+        }
+    ],
+    "dispenseRequest": {
+        "validityPeriod": {
+            "start": "2022-10-04"
+        }
+    },
+    "context": {
+        "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+    }
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-request-prescribed-by-gp-practice.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-request-prescribed-by-gp-practice.json
@@ -1,0 +1,69 @@
+{
+    "resourceType": "MedicationRequest",
+    "id": "mr-0614dac8-43b0-11ed-bf45-0a0bbb679524",
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "mr-0614dac8-43b0-11ed-bf45-0a0bbb679524"
+        }
+    ],
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                        "code": "acute",
+                        "display": "Acute"
+                    }
+                ]
+            }
+        }
+    ],
+    "status": "completed",
+    "intent": "plan",
+    "medicationReference": {
+        "reference": "Medication/26148711000001101"
+    },
+    "subject": {
+        "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+    },
+    "authoredOn": "2022-10-04",
+    "recorder": {
+        "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+    },
+    "requester": {
+        "agent": {
+            "reference": "Organization/F85003"
+        }
+    },
+    "dosageInstruction": [
+        {
+            "text": "One puff as needed. Max 10 doses per day"
+        }
+    ],
+    "dispenseRequest": {
+        "validityPeriod": {
+            "start": "2022-10-04",
+            "end": "2022-11-01"
+        },
+        "quantity": {
+            "value": 1,
+            "unit": "dose"
+        },
+        "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+        }
+    },
+    "context": {
+        "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+    }
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-request-prescribed-by-previous-practice.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-request-prescribed-by-previous-practice.json
@@ -1,0 +1,69 @@
+{
+    "resourceType": "MedicationRequest",
+    "id": "mr-4c816c87-09b5-4bec-bae4-e81855758da7",
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "mr-4c816c87-09b5-4bec-bae4-e81855758da7"
+        }
+    ],
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                        "code": "acute",
+                        "display": "Acute"
+                    }
+                ]
+            }
+        }
+    ],
+    "status": "completed",
+    "intent": "plan",
+    "medicationReference": {
+        "reference": "Medication/26148711000001101"
+    },
+    "subject": {
+        "reference": "Patient/00d756ae-360d-11ed-95ee-060b232f1aa2"
+    },
+    "authoredOn": "2022-10-04",
+    "recorder": {
+        "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+    },
+    "requester": {
+        "agent": {
+            "reference": "Organization/F85003"
+        }
+    },
+    "dosageInstruction": [
+        {
+            "text": "One puff as needed. Max 10 doses per day"
+        }
+    ],
+    "dispenseRequest": {
+        "validityPeriod": {
+            "start": "2022-10-04",
+            "end": "2022-11-01"
+        },
+        "quantity": {
+            "value": 1,
+            "unit": "dose"
+        },
+        "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+        }
+    },
+    "context": {
+        "reference": "Encounter/e61ec0cc-43ae-11ed-ba7c-0a0bbb679524"
+    }
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-nhs-prescription.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-nhs-prescription.xml
@@ -1,0 +1,53 @@
+<component typeCode="COMP">
+    <MedicationStatement classCode="SBADM" moodCode="INT">
+        <id root="394559384658936"/>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20221004"/>
+            <high value="20221101"/>
+        </effectiveTime>
+        <availabilityTime value="20221004"/>
+        <consumable typeCode="CSM">
+            <manufacturedProduct classCode="MANU">
+                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                    <code code="26148711000001101" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                          displayName="Beclometasone 100micrograms/dose / Formoterol 6micrograms/dose dry powder inhaler">
+                    </code>
+                </manufacturedMaterial>
+            </manufacturedProduct>
+        </consumable>
+        <component typeCode="COMP">
+            <ehrSupplyAuthorise>
+                <id root="394559384658936"/>
+                <code code="394823007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="NHS Prescription">
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20221004"/><high value="20221101"/>
+                </effectiveTime>
+                <availabilityTime value="20221004"/>
+                <repeatNumber value="0"/>
+                <quantity value="1" unit="1">
+                    <translation value="1">
+                        <originalText>dose</originalText>
+                    </translation>
+                </quantity>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation>
+                        <text>Expected Supply Duration: 28 days</text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyAuthorise>
+        </component>
+        <pertinentInformation typeCode="PERT">
+            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                <text>One puff as needed. Max 10 doses per day</text>
+            </pertinentMedicationDosage>
+        </pertinentInformation>
+        <Participant typeCode="AUT" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root=""/>
+            </agentRef>
+        </Participant>
+    </MedicationStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-prescribed-by-another-organisation.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-prescribed-by-another-organisation.xml
@@ -1,0 +1,51 @@
+<component typeCode="COMP">
+    <MedicationStatement classCode="SBADM" moodCode="INT">
+        <id root="394559384658936"/>
+        <statusCode code="ACTIVE"/>
+        <effectiveTime>
+            <low value="20221004"/>
+        </effectiveTime>
+        <availabilityTime value="20221004"/>
+        <consumable typeCode="CSM">
+            <manufacturedProduct classCode="MANU">
+                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                    <code code="412556009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Co-codamol">
+                    </code>
+                </manufacturedMaterial>
+            </manufacturedProduct>
+        </consumable>
+        <component typeCode="COMP">
+            <ehrSupplyAuthorise>
+                <id root="394559384658936"/>
+                <code code="394828003" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prescription by another organisation">
+                </code>
+                <statusCode code="ACTIVE"/>
+                <effectiveTime>
+                    <low value="20221004"/>
+                </effectiveTime>
+                <availabilityTime value="20221004"/>
+                <repeatNumber value="1"/>
+                <quantity value="1" unit="1">
+                    <translation value="1">
+                        <originalText>Unk UoM</originalText>
+                    </translation>
+                </quantity>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation>
+                        <text></text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyAuthorise>
+        </component>
+        <pertinentInformation typeCode="PERT">
+            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                <text>0.1ml once per day</text>
+            </pertinentMedicationDosage>
+        </pertinentInformation>
+        <Participant typeCode="AUT" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root=""/>
+            </agentRef>
+        </Participant>
+    </MedicationStatement>
+</component>


### PR DESCRIPTION
*Description*

Within the GP2GP message created from the Medicus E2E test, Peter Salisbury has identified that the SNOMED code used in <ehrSupplyAuthorise> for the “Prescribed  elsewhere” medication is incorrect. 

This line 537…
```
<code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
 ```                                               

should be…

```
<code code="394828003" displayName="Prescription by another organisation" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/> 
```