### PR TITLE
NIAD-2402: Add fromAsid and toAsid to EHR status endpoint.

### DIFF
--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/model/EhrStatus.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/model/EhrStatus.java
@@ -11,6 +11,8 @@ public class EhrStatus {
     private List<ReceivedAck> migrationLog;
     private MigrationStatus migrationStatus;
     private Instant originalRequestDate;
+    private String fromAsid;
+    private String toAsid;
 
     @Data
     public static class ReceivedAck {

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/status/EhrStatusEndpointTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/status/EhrStatusEndpointTest.java
@@ -1,0 +1,116 @@
+package uk.nhs.adaptors.gp2gp.ehr.status;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.SneakyThrows;
+import uk.nhs.adaptors.gp2gp.ehr.InboundMessageHandlingTest;
+import uk.nhs.adaptors.gp2gp.ehr.status.model.EhrStatus;
+import uk.nhs.adaptors.gp2gp.mhs.InboundMessage;
+import uk.nhs.adaptors.gp2gp.testcontainers.ActiveMQExtension;
+import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
+
+@RunWith(SpringRunner.class)
+@ExtendWith({SpringExtension.class, MongoDBExtension.class, ActiveMQExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext
+public class EhrStatusEndpointTest {
+
+    private static final String INBOUND_QUEUE_NAME = "inbound";
+    private static final String EBXML_PATH_REQUEST_MESSAGE = "/requestmessage/RCMR_IN010000UK05_ebxml.txt";
+    private static final String PAYLOAD_PATH_REQUEST_MESSAGE = "/requestmessage/RCMR_IN010000UK05_payload.txt";
+    private static final String TO_ASID = "715373337545";
+    private static final String FROM_ASID = "276827251543";
+    private static final int JMS_RECEIVE_TIMEOUT = 60000;
+    private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private TestRestTemplate restTemplate;
+    private String conversationId;
+    private String ehrStatusEndpoint;
+
+    private static final String CONVERSATION_ID_PLACEHOLDER = "{{conversationId}}";
+
+    @BeforeEach
+    public void setUp() {
+        inboundJmsTemplate.setDefaultDestinationName(INBOUND_QUEUE_NAME);
+        conversationId = UUID.randomUUID().toString();
+        ehrStatusEndpoint = "http://localhost:" + port + "/ehr-status/" + conversationId;
+
+        inboundJmsTemplate.setReceiveTimeout(JMS_RECEIVE_TIMEOUT);
+    }
+
+    @Autowired
+    private JmsTemplate inboundJmsTemplate;
+
+    @Test
+    public void When_EhrStatusEndpointHasContent_Expect_StatusEndpointReturnsAsidCodes() {
+
+        var inboundMessage = new InboundMessage();
+        var payload = readResourceAsString(PAYLOAD_PATH_REQUEST_MESSAGE);
+        var ebxml = readResourceAsString(EBXML_PATH_REQUEST_MESSAGE).replace(CONVERSATION_ID_PLACEHOLDER, conversationId);
+
+        inboundMessage.setEbXML(ebxml);
+        inboundMessage.setPayload(payload);
+
+        inboundJmsTemplate.send(session -> session.createTextMessage(parseMessageToString(inboundMessage)));
+
+        await()
+            .atMost(ONE_MINUTE)
+            .until(this::ehrEndpointHasContent);
+
+        EhrStatus status = restTemplate.getForObject(ehrStatusEndpoint, EhrStatus.class);
+
+        assertThat(status.getFromAsid()).isEqualTo(FROM_ASID);
+        assertThat(status.getToAsid()).isEqualTo(TO_ASID);
+    }
+
+    @SneakyThrows
+    private String parseMessageToString(InboundMessage inboundMessage) {
+        return objectMapper.writeValueAsString(inboundMessage);
+    }
+
+    @SneakyThrows
+    private static String readResourceAsString(String path) {
+        try (InputStream is = InboundMessageHandlingTest.class.getResourceAsStream(path)) {
+            if (is == null) {
+                throw new FileNotFoundException(path);
+            }
+            return IOUtils.toString(is, UTF_8);
+        }
+    }
+
+    private boolean ehrEndpointHasContent() {
+        var responseEntity = restTemplate.getForEntity(ehrStatusEndpoint, EhrStatus.class);
+
+        return responseEntity.getStatusCode() == HttpStatus.OK;
+    }
+}

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/util/ProcessDetectionService.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/util/ProcessDetectionService.java
@@ -1,0 +1,83 @@
+package uk.nhs.adaptors.gp2gp.util;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusRepository;
+
+@Component
+public class ProcessDetectionService {
+
+    private final EhrExtractStatusRepository ehrExtractStatusRepository;
+
+    private static final String ACK_TYPE_CODE = "AA";
+
+    @Autowired
+    public ProcessDetectionService(EhrExtractStatusRepository ehrExtractStatusRepository) {
+        this.ehrExtractStatusRepository = ehrExtractStatusRepository;
+    }
+
+    public boolean awaitingContinue(String conversationId) {
+        var dbExtractOptional = ehrExtractStatusRepository.findByConversationId(conversationId);
+        if (dbExtractOptional.isEmpty()) {
+            return false;
+        }
+        var dbExtract = dbExtractOptional.orElseThrow();
+        var ehrCorePendingOptional = Optional.ofNullable(dbExtract.getEhrExtractCorePending());
+        var ackPending = Optional.ofNullable(dbExtract.getAckPending());
+
+        return ehrCorePendingOptional.isPresent() && ackPending.isEmpty();
+    }
+
+    public boolean awaitingAck(String conversationId) {
+        var dbExtractOptional = ehrExtractStatusRepository.findByConversationId(conversationId);
+        if (dbExtractOptional.isEmpty()) {
+            return false;
+        }
+        var dbExtract = dbExtractOptional.orElseThrow();
+        var ackPending = Optional.ofNullable(dbExtract.getAckPending());
+
+        return ackPending.isPresent();
+    }
+
+    public boolean transferComplete(String conversationId) {
+        var finalDbExtractOptional = ehrExtractStatusRepository.findByConversationId(conversationId);
+        if (finalDbExtractOptional.isEmpty()) {
+            return false;
+        }
+        var finalDbExtract = finalDbExtractOptional.orElseThrow();
+        var ackPendingOptional = Optional.ofNullable(finalDbExtract.getAckPending());
+        var ackToRequestorOptional = Optional.ofNullable(finalDbExtract.getAckToRequester());
+        var errorOptional = Optional.ofNullable(finalDbExtract.getError());
+        var receivedAcknowledgementOptional = Optional.ofNullable(finalDbExtract.getEhrReceivedAcknowledgement());
+
+        return ackPendingOptional
+            .map(ackPending -> ackPending.getTypeCode().equals(ACK_TYPE_CODE))
+            .orElse(false)
+
+            && ackToRequestorOptional
+            .map(ackToRequester -> ackToRequester.getTypeCode().equals(ACK_TYPE_CODE))
+            .orElse(false)
+
+            && errorOptional.isEmpty()
+
+            && receivedAcknowledgementOptional
+            .map(acknowledgement ->
+                Optional.ofNullable(acknowledgement.getConversationClosed()).isPresent()
+                    && Optional.ofNullable(acknowledgement.getErrors()).isEmpty())
+            .orElse(false);
+    }
+
+    public boolean processFailed(String conversationId) {
+        var finalDbExtractOptional = ehrExtractStatusRepository.findByConversationId(conversationId);
+        if (finalDbExtractOptional.isEmpty()) {
+            return false;
+        }
+        var finalDbExtract = finalDbExtractOptional.orElseThrow();
+        var extractError = Optional.ofNullable(finalDbExtract.getError());
+
+        return extractError.isPresent();
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/model/EhrStatus.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/model/EhrStatus.java
@@ -16,6 +16,8 @@ public class EhrStatus {
     private List<EhrExtractStatus.EhrReceivedAcknowledgement> migrationLog;
     private MigrationStatus migrationStatus;
     private Instant originalRequestDate;
+    private String fromAsid;
+    private String toAsid;
 
     @Builder
     @Data

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusService.java
@@ -53,6 +53,8 @@ public class EhrStatusService {
                 .migrationLog(receivedAcknowledgements)
                 .migrationStatus(evaluateMigrationStatus(ehrExtractStatus, attachmentStatusList))
                 .originalRequestDate(ehrExtractStatus.getCreated())
+                .fromAsid(ehrExtractStatus.getEhrRequest().getFromAsid())
+                .toAsid(ehrExtractStatus.getEhrRequest().getToAsid())
                 .build());
     }
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusServiceTest.java
@@ -32,16 +32,21 @@ import uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus;
 @ExtendWith(MockitoExtension.class)
 public class EhrStatusServiceTest {
 
+    private static final String TO_ASID_CODE = "test-to-asid";
+    private static final String FROM_ASID_CODE = "test-from-asid";
+
     private static final EhrExtractStatus COMPLETE_EHR_EXTRACT_STATUS = EhrExtractStatus.builder()
         .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AA").build())
         .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AA").build())
         .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().conversationClosed(Instant.now()).build())
+        .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
     private static final EhrExtractStatus FAILED_NME_EXTRACT_STATUS = EhrExtractStatus.builder()
         .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AE").build())
         .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AE").build())
         .error(EhrExtractStatus.Error.builder().code("18").occurredAt(Instant.now()).build())
+        .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
     private static final EhrExtractStatus FAILED_INCUMBENT_EXTRACT_STATUS_1 = EhrExtractStatus.builder()
@@ -53,6 +58,7 @@ public class EhrStatusServiceTest {
                     .display("Test Error")
                     .build()))
             .build())
+        .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
     private static final EhrExtractStatus FAILED_INCUMBENT_EXTRACT_STATUS_2 = EhrExtractStatus.builder()
@@ -62,11 +68,13 @@ public class EhrStatusServiceTest {
                     .display("Test Error")
                     .build()))
             .build())
+        .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
     private static final EhrExtractStatus IN_PROGRESS_EXTRACT_STATUS = EhrExtractStatus.builder()
         .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AA").build())
         .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AA").build())
+        .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
     private static final EhrExtractStatus.GpcDocument SKELETON_DOCUMENT = EhrExtractStatus.GpcDocument.builder()
@@ -192,6 +200,19 @@ public class EhrStatusServiceTest {
         FileStatus fileStatus = ehrStatusService.getFileStatus(ORIGINAL_FILE_DOCUMENT, ONE_FAILED_ACK_LIST);
 
         assertThat(fileStatus).isEqualTo(ERROR);
+    }
+
+    @Test
+    public void When_GetFileStatus_Expect_AsidCodesArePresent() {
+        when(extractStatusRepository.findByConversationId(any())).thenReturn(Optional.of(COMPLETE_EHR_EXTRACT_STATUS));
+
+        Optional<EhrStatus> statusOptional = ehrStatusService.getEhrStatus(UUID.randomUUID().toString());
+
+        EhrStatus status = statusOptional.orElseThrow();
+
+        assertThat(status.getToAsid()).isEqualTo(TO_ASID_CODE);
+        assertThat(status.getFromAsid()).isEqualTo(FROM_ASID_CODE);
+
     }
 
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusServiceTest.java
@@ -42,12 +42,6 @@ public class EhrStatusServiceTest {
         .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
-    private static final EhrExtractStatus MISSING_ASID_EHR_EXTRACT_STATUS =
-        EhrExtractStatus.builder()
-            .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AA").build())
-            .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AA").build())
-            .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().conversationClosed(Instant.now()).build())
-            .build();
     private static final EhrExtractStatus FAILED_NME_EXTRACT_STATUS = EhrExtractStatus.builder()
         .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AE").build())
         .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AE").build())

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusServiceTest.java
@@ -42,6 +42,12 @@ public class EhrStatusServiceTest {
         .ehrRequest(EhrExtractStatus.EhrRequest.builder().toAsid(TO_ASID_CODE).fromAsid(FROM_ASID_CODE).build())
         .build();
 
+    private static final EhrExtractStatus MISSING_ASID_EHR_EXTRACT_STATUS =
+        EhrExtractStatus.builder()
+            .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AA").build())
+            .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AA").build())
+            .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().conversationClosed(Instant.now()).build())
+            .build();
     private static final EhrExtractStatus FAILED_NME_EXTRACT_STATUS = EhrExtractStatus.builder()
         .ackPending(EhrExtractStatus.AckPending.builder().typeCode("AE").build())
         .ackToRequester(EhrExtractStatus.AckToRequester.builder().typeCode("AE").build())
@@ -203,7 +209,7 @@ public class EhrStatusServiceTest {
     }
 
     @Test
-    public void When_GetFileStatus_Expect_AsidCodesArePresent() {
+    public void When_GetEhrStatus_Expect_AsidCodesArePresent() {
         when(extractStatusRepository.findByConversationId(any())).thenReturn(Optional.of(COMPLETE_EHR_EXTRACT_STATUS));
 
         Optional<EhrStatus> statusOptional = ehrStatusService.getEhrStatus(UUID.randomUUID().toString());


### PR DESCRIPTION
Since the introduction on the ASID override variables in the GP2GP adaptor, it is possible to lose the original ASID provided by the given EHR message.

Scenerio 1

GIVEN an EHR request is received
THEN the toASID and fromASID fields should be recorded against the EHR in the Database. 

Scenerio 2

Given a request is made to the status endpoint for a given Conversation ID
THEN the toAsid and fromAsid fields original given for the EHR request should be returned in the json e.g.

{
    fromASID: “…“,
    toASID: “….“
    ….
}