### PR TITLE
NIAD-2414: Mapping bug - Topic not mapped

### DIFF
--- a/docker/wiremock/stubs/__files/correctPatientNoDocsStructuredRecordResponse.json
+++ b/docker/wiremock/stubs/__files/correctPatientNoDocsStructuredRecordResponse.json
@@ -842,19 +842,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-A-Anxiety-With-Depression"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Anxiety with Depression",
@@ -1180,19 +1167,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-B-Swollen-Legs"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Swollen legs",
@@ -1537,19 +1511,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-D-URTI"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Upper respiratory tract infection",
@@ -1612,19 +1573,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-D-URTI"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "History",
@@ -4278,19 +4226,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-A-Anxiety-With-Depression"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Anxiety with Depression",
@@ -4363,19 +4298,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-E-Post-viral-cough"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Upper respiratory tract infection",
@@ -5412,19 +5334,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-A-Anxiety-With-Depression"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Anxiety with Depression",
@@ -5497,19 +5406,6 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/Problem-B-Swollen-Legs"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "status": "current",
                 "mode": "snapshot",
                 "title": "Swollen legs",

--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -51,7 +51,7 @@ public class EhrExtractTest {
     //NORMAL-DR = Non-AbsentAttachment DocumentReference
     private static final String NHS_NUMBER_WITH_AA_DR = "9690937286";
     private static final String NHS_NUMBER_WITH_NORMAL_DR = "9690937287";
-    private static final String NHS_NUMBER_NOT_EXISTING_PATIENT = "9876543210";
+    private static final String NHS_NUMBER_NOT_EXISTING_PATIENT = "9600000001";
     private static final String NHS_NUMBER_NO_DOCUMENTS = "9690937294";
     private static final String NHS_NUMBER_LARGE_DOCUMENTS_1 = "9690937819";
     private static final String NHS_NUMBER_LARGE_DOCUMENTS_2 = "9690937841";

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -46,6 +46,8 @@ public class CodeableConceptCdMapper {
     private static final String EHR_SUPPLY_TYPE_ANOTHER_ORGANISATION_DISPLAY = "Prescription by another organisation";
     private static final String UNSPECIFIED_PROBLEM_CODE = "394776006";
     private static final String UNSPECIFIED_PROBLEM_DESCRIPTION = "Unspecified problem";
+    private static final String OTHER_CATEGORY_CODE = "394841004";
+    private static final String OTHER_CATEGORY_DESCRIPTION = "Other category";
 
     public String mapCodeableConceptToCd(CodeableConcept codeableConcept) {
         var builder = CodeableConceptCdTemplateParameters.builder();
@@ -188,7 +190,7 @@ public class CodeableConceptCdMapper {
         return Optional.of(TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build()));
     }
 
-    public String mapCdForTopic() {
+    public String getCdForTopic() {
         var params = CodeableConceptCdTemplateParameters.builder()
             .mainCode(UNSPECIFIED_PROBLEM_CODE)
             .mainCodeSystem(SNOMED_SYSTEM_CODE)
@@ -198,11 +200,11 @@ public class CodeableConceptCdMapper {
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, params);
     }
 
-    public String mapCdForTopic(CodeableConcept relatedProblem, String title) {
+    public String mapToCdForTopic(CodeableConcept relatedProblem, String title) {
         var mainCode = findMainCode(relatedProblem);
 
         if (mainCode.isEmpty()) {
-            return mapCdForTopic(title);
+            return mapToCdForTopic(title);
         }
 
         var params = prepareTemplateParameters(mainCode.orElseThrow());
@@ -211,11 +213,11 @@ public class CodeableConceptCdMapper {
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, params);
     }
 
-    public String mapCdForTopic(CodeableConcept relatedProblem) {
+    public String mapToCdForTopic(CodeableConcept relatedProblem) {
         var mainCode = findMainCode(relatedProblem);
 
         if (mainCode.isEmpty()) {
-            return mapCdForTopic();
+            return getCdForTopic();
         }
 
         var params = prepareTemplateParameters(mainCode.orElseThrow());
@@ -223,7 +225,7 @@ public class CodeableConceptCdMapper {
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, params);
     }
 
-    public String mapCdForTopic(String title) {
+    public String mapToCdForTopic(String title) {
         var params = CodeableConceptCdTemplateParameters.builder()
             .mainCode(UNSPECIFIED_PROBLEM_CODE)
             .mainCodeSystem(SNOMED_SYSTEM_CODE)
@@ -233,6 +235,27 @@ public class CodeableConceptCdMapper {
 
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, params);
 
+    }
+
+    public String mapToCdForCategory(String title) {
+        var params = CodeableConceptCdTemplateParameters.builder()
+            .mainCode(OTHER_CATEGORY_CODE)
+            .mainCodeSystem(SNOMED_SYSTEM_CODE)
+            .mainDisplayName(OTHER_CATEGORY_DESCRIPTION)
+            .mainOriginalText(title)
+            .build();
+
+        return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, params);
+    }
+
+    public String getCdForCategory() {
+        var params = CodeableConceptCdTemplateParameters.builder()
+            .mainCode(OTHER_CATEGORY_CODE)
+            .mainCodeSystem(SNOMED_SYSTEM_CODE)
+            .mainDisplayName(OTHER_CATEGORY_DESCRIPTION)
+            .build();
+
+        return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, params);
     }
 
     private CodeableConceptCdTemplateParameters prepareTemplateParameters(Coding mainCode) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CompoundStatementClassCode.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CompoundStatementClassCode.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @Getter
 public enum CompoundStatementClassCode {
     BATTERY("BATTERY"),
-    CLUSTER("CLUSTER");
+    CLUSTER("CLUSTER"),
+    TOPIC("TOPIC"),
+    CATEGORY("CATEGORY");
 
     private final String code;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -175,7 +175,7 @@ public class EncounterComponentsMapper {
                 .nested(true)
                 .id(messageContext.getIdMapper().getOrNew(ResourceType.List, categoryList.getIdElement()))
                 .classCode(CATEGORY.getCode())
-                .compoundStatementCode(codeableConceptCdMapper.mapCodeableConceptToCd(categoryList.getCode()))
+                .compoundStatementCode(prepareCdForCategory(categoryList))
                 .statusCode(COMPLETE_CODE)
                 .effectiveTime(effectiveTime)
                 .availabilityTime(availabilityTime)
@@ -307,18 +307,26 @@ public class EncounterComponentsMapper {
         Optional<String> title = Optional.ofNullable(topicList.getTitle());
 
         if (relatedProblem.isPresent() && title.isPresent()) {
-            return codeableConceptCdMapper.mapCdForTopic(relatedProblem.orElseThrow(), title.orElseThrow());
+            return codeableConceptCdMapper.mapToCdForTopic(relatedProblem.orElseThrow(), title.orElseThrow());
         }
 
         if (relatedProblem.isPresent()) {
-            return codeableConceptCdMapper.mapCdForTopic(relatedProblem.orElseThrow());
+            return codeableConceptCdMapper.mapToCdForTopic(relatedProblem.orElseThrow());
         }
 
         if (title.isPresent()) {
-            return codeableConceptCdMapper.mapCdForTopic(title.orElseThrow());
+            return codeableConceptCdMapper.mapToCdForTopic(title.orElseThrow());
         }
 
-        return codeableConceptCdMapper.mapCdForTopic();
+        return codeableConceptCdMapper.getCdForTopic();
+    }
+
+    private String prepareCdForCategory(ListResource categoryList) {
+        Optional<String> title = Optional.ofNullable(categoryList.getTitle());
+
+        return title
+            .map(codeableConceptCdMapper::mapToCdForCategory)
+            .orElse(codeableConceptCdMapper.getCdForCategory());
     }
 
     private String prepareEffectiveTime(ListResource listResource) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -57,7 +57,8 @@ public class EncounterComponentsMapper {
     private static final boolean IS_NESTED = false;
     private static final String NIAD_1409_INVALID_REFERENCE = "Referral items are not supported by the provider system";
     private static final Mustache COMPOUND_STATEMENT_TEMPLATE = TemplateUtils.loadTemplate("ehr_compound_statement_template.mustache");
-    private static final String RELATED_PROBLEM_EXTENSION_URL = "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1";
+    private static final String RELATED_PROBLEM_EXTENSION_URL = "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect"
+        + "-RelatedProblemHeader-1";
     private static final String RELATED_PROBLEM_TARGET = "target";
     private static final String COMPLETE_CODE = "COMPLETE";
 
@@ -111,13 +112,13 @@ public class EncounterComponentsMapper {
     private String mapTopicListToComponent(ListResource topicList) {
 
         if (!CodeableConceptMappingUtils.hasCode(topicList.getCode(), List.of(TOPIC_LIST_CODE))) {
-            throw new EhrMapperException(String.format("Unexpected list %s referenced in Consultation, expected list to be coded as " +
-                "Topic (EHR)", topicList.getId()));
+            throw new EhrMapperException(String.format("Unexpected list %s referenced in Consultation, expected list to be coded as "
+                + "Topic (EHR)", topicList.getId()));
         }
 
         String components = mapTopicListComponents(topicList);
 
-        if(StringUtils.isAllEmpty(components)) {
+        if (StringUtils.isAllEmpty(components)) {
             return components;
         }
 
@@ -158,31 +159,31 @@ public class EncounterComponentsMapper {
     private String mapCategoryListToComponent(ListResource categoryList) {
 
         if (!CodeableConceptMappingUtils.hasCode(categoryList.getCode(), List.of(CATEGORY_LIST_CODE))) {
-            throw new EhrMapperException(String.format("Unexpected list %s referenced in Topic (EHR), expected list to be coded as " +
-                "Category (EHR)", categoryList.getId()));
+            throw new EhrMapperException(String.format("Unexpected list %s referenced in Topic (EHR), expected list to be coded as "
+                + "Category (EHR)", categoryList.getId()));
         }
 
-            String components = mapListResourceToComponents(categoryList);
+        String components = mapListResourceToComponents(categoryList);
 
-            if (StringUtils.isAllEmpty(components)) {
-                return components;
-            }
+        if (StringUtils.isAllEmpty(components)) {
+            return components;
+        }
 
-            String effectiveTime = prepareEffectiveTime(categoryList);
-            String availabilityTime = prepareAvailabilityTime(categoryList);
+        String effectiveTime = prepareEffectiveTime(categoryList);
+        String availabilityTime = prepareAvailabilityTime(categoryList);
 
-            var params = CompoundStatementParameters.builder()
-                .nested(true)
-                .id(messageContext.getIdMapper().getOrNew(ResourceType.List, categoryList.getIdElement()))
-                .classCode(CATEGORY.getCode())
-                .compoundStatementCode(prepareCdForCategory(categoryList))
-                .statusCode(COMPLETE_CODE)
-                .effectiveTime(effectiveTime)
-                .availabilityTime(availabilityTime)
-                .components(components)
-                .build();
+        var params = CompoundStatementParameters.builder()
+            .nested(true)
+            .id(messageContext.getIdMapper().getOrNew(ResourceType.List, categoryList.getIdElement()))
+            .classCode(CATEGORY.getCode())
+            .compoundStatementCode(prepareCdForCategory(categoryList))
+            .statusCode(COMPLETE_CODE)
+            .effectiveTime(effectiveTime)
+            .availabilityTime(availabilityTime)
+            .components(components)
+            .build();
 
-            return TemplateUtils.fillTemplate(COMPOUND_STATEMENT_TEMPLATE, params);
+        return TemplateUtils.fillTemplate(COMPOUND_STATEMENT_TEMPLATE, params);
     }
 
     private String mapListResourceToComponents(ListResource listResource) {
@@ -220,8 +221,7 @@ public class EncounterComponentsMapper {
             }
 
             return Optional.empty();
-        }
-        else {
+        } else {
             throw new EhrMapperException("Unsupported resource in consultation list: " + resource.getId());
         }
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/CompoundStatementParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/CompoundStatementParameters.java
@@ -1,0 +1,19 @@
+package uk.nhs.adaptors.gp2gp.ehr.mapper.parameters;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class CompoundStatementParameters {
+    private boolean nested;
+    private String classCode;
+    private String id;
+    private String compoundStatementCode;
+    private String statusCode;
+    private String effectiveTime;
+    private String availabilityTime;
+    private String components;
+}

--- a/service/src/main/resources/templates/ehr_compound_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_compound_statement_template.mustache
@@ -1,0 +1,12 @@
+<component typeCode="COMP" {{#nested}}contextConductionInd="true"{{/nested}}>
+    <CompoundStatement classCode="{{classCode}}" moodCode="EVN">
+        <id root="{{id}}" />
+        {{{compoundStatementCode}}}
+        <statusCode code="{{statusCode}}" />
+        <effectiveTime>
+            {{{effectiveTime}}}
+        </effectiveTime>
+        {{{availabilityTime}}}
+        {{{components}}}
+    </CompoundStatement>
+</component>

--- a/service/src/main/resources/templates/ehr_compound_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_compound_statement_template.mustache
@@ -1,8 +1,8 @@
-<component typeCode="COMP" {{#nested}}contextConductionInd="true"{{/nested}}>
+<component typeCode="COMP"{{#nested}} contextConductionInd="true"{{/nested}}>
     <CompoundStatement classCode="{{classCode}}" moodCode="EVN">
-        <id root="{{id}}" />
+        <id root="{{id}}"/>
         {{{compoundStatementCode}}}
-        <statusCode code="{{statusCode}}" />
+        <statusCode code="{{statusCode}}"/>
         <effectiveTime>
             {{{effectiveTime}}}
         </effectiveTime>

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -6,12 +6,15 @@ import java.io.IOException;
 import java.util.stream.Stream;
 
 import org.hl7.fhir.dstu3.model.AllergyIntolerance;
+import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import lombok.SneakyThrows;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 import uk.nhs.adaptors.gp2gp.utils.TestArgumentsLoaderUtil;
@@ -21,6 +24,12 @@ public class CodeableConceptCdMapperTest {
     private static final String TEST_FILE_DIRECTORY_NULL_FLAVOR = "/ehr/mapper/codeableconcept/nullFlavor/";
     private static final String TEST_FILE_DIRECTORY_ACTUAL_PROBLEM = "/ehr/mapper/codeableconcept/actualProblem/";
     private static final String TEST_FILE_DIRECTORY_ALLERGY_CLINICAL_STATUS = "/ehr/mapper/codeableconcept/allergyClinicalStatus/";
+    private static final String TEST_FILE_TOPIC_RELATED_CONDITION = TEST_FILE_DIRECTORY + "topic/codeable_concept_snowmed_related_condtition.json";
+    private static final String CD_FOR_TOPIC_RELATED_PROBLEM_AND_TITLE = TEST_FILE_DIRECTORY + "topic/cd_for_topic_related_problem_and_title.xml";
+    private static final String CD_FOR_TOPIC_TITLE = TEST_FILE_DIRECTORY + "topic/cd_for_topic_title.xml";
+    private static final String CD_FOR_TOPIC_UNSPECIFIED = TEST_FILE_DIRECTORY + "topic/cd_for_topic_unspecified.xml";
+    private static final String TEST_FILE_DIRECTORY_TOPIC_RELATED_PROBLEM = TEST_FILE_DIRECTORY + "topic/relatedProblem/";
+    private static final String TEST_TITLE = "test title";
 
     private FhirParseService fhirParseService;
     private CodeableConceptCdMapper codeableConceptCdMapper;
@@ -39,6 +48,10 @@ public class CodeableConceptCdMapperTest {
 
     private static Stream<Arguments> getTestArgumentsAllergyClinicalStatus() {
         return TestArgumentsLoaderUtil.readTestCases(TEST_FILE_DIRECTORY_ALLERGY_CLINICAL_STATUS);
+    }
+
+    private static Stream<Arguments> getTestArgumentsForTopicRelatedProblem() {
+        return TestArgumentsLoaderUtil.readTestCases(TEST_FILE_DIRECTORY_TOPIC_RELATED_PROBLEM);
     }
 
     @BeforeEach
@@ -100,6 +113,56 @@ public class CodeableConceptCdMapperTest {
             AllergyIntolerance.AllergyIntoleranceClinicalStatus.RESOLVED);
         assertThat(outputMessage)
             .describedAs(TestArgumentsLoaderUtil.FAIL_MESSAGE, inputJson, outputXml)
+            .isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestArgumentsForTopicRelatedProblem")
+    @SneakyThrows
+    public void When_MappingCdForTopic_With_RelatedProblem_Expect_HL7CdObjectXml(String inputJson, String outputXml) {
+        var condition = ResourceTestFileUtils.getFileContent(inputJson);
+        var codeableConcept = fhirParseService.parseResource(condition, Condition.class).getCode();
+        var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
+
+        var outputString = codeableConceptCdMapper.mapCdForTopic(codeableConcept);
+
+        assertThat(outputString)
+            .describedAs(TestArgumentsLoaderUtil.FAIL_MESSAGE, inputJson, outputXml)
+            .isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_MapCdForTopic_With_RelatedProblemAndTitle_Expect_ProblemCodeAndTitleAreUsed() {
+        var relatedProblem = ResourceTestFileUtils.getFileContent(TEST_FILE_TOPIC_RELATED_CONDITION);
+        var codeableConcept = fhirParseService.parseResource(relatedProblem, Condition.class).getCode();
+        var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_TOPIC_RELATED_PROBLEM_AND_TITLE);
+
+        var outputString = codeableConceptCdMapper.mapCdForTopic(codeableConcept, TEST_TITLE);
+
+        assertThat(outputString)
+            .isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_MapCdForTopic_With_TitleOnly_Expect_UnspecifiedProblemAndTitle() {
+        var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_TOPIC_TITLE);
+
+        var outputString = codeableConceptCdMapper.mapCdForTopic(TEST_TITLE);
+
+        assertThat(outputString)
+            .isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_MapCdForTopic_Without_RelatedProblemOrTile_Expect_UnspecifiedProblem() {
+        var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_TOPIC_UNSPECIFIED);
+
+        var outputString = codeableConceptCdMapper.mapCdForTopic();
+
+        assertThat(outputString)
             .isEqualToIgnoringWhitespace(expectedOutput);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -24,8 +24,10 @@ public class CodeableConceptCdMapperTest {
     private static final String TEST_FILE_DIRECTORY_NULL_FLAVOR = "/ehr/mapper/codeableconcept/nullFlavor/";
     private static final String TEST_FILE_DIRECTORY_ACTUAL_PROBLEM = "/ehr/mapper/codeableconcept/actualProblem/";
     private static final String TEST_FILE_DIRECTORY_ALLERGY_CLINICAL_STATUS = "/ehr/mapper/codeableconcept/allergyClinicalStatus/";
-    private static final String TEST_FILE_TOPIC_RELATED_CONDITION = TEST_FILE_DIRECTORY + "topic/codeable_concept_snowmed_related_condtition.json";
-    private static final String CD_FOR_TOPIC_RELATED_PROBLEM_AND_TITLE = TEST_FILE_DIRECTORY + "topic/cd_for_topic_related_problem_and_title.xml";
+    private static final String TEST_FILE_TOPIC_RELATED_CONDITION = TEST_FILE_DIRECTORY
+        + "topic/codeable_concept_snowmed_related_condtition.json";
+    private static final String CD_FOR_TOPIC_RELATED_PROBLEM_AND_TITLE = TEST_FILE_DIRECTORY
+        + "topic/cd_for_topic_related_problem_and_title.xml";
     private static final String CD_FOR_TOPIC_TITLE = TEST_FILE_DIRECTORY + "topic/cd_for_topic_title.xml";
     private static final String CD_FOR_TOPIC_UNSPECIFIED = TEST_FILE_DIRECTORY + "topic/cd_for_topic_unspecified.xml";
     private static final String TEST_FILE_DIRECTORY_TOPIC_RELATED_PROBLEM = TEST_FILE_DIRECTORY + "topic/relatedProblem/";

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -29,6 +29,8 @@ public class CodeableConceptCdMapperTest {
     private static final String CD_FOR_TOPIC_TITLE = TEST_FILE_DIRECTORY + "topic/cd_for_topic_title.xml";
     private static final String CD_FOR_TOPIC_UNSPECIFIED = TEST_FILE_DIRECTORY + "topic/cd_for_topic_unspecified.xml";
     private static final String TEST_FILE_DIRECTORY_TOPIC_RELATED_PROBLEM = TEST_FILE_DIRECTORY + "topic/relatedProblem/";
+    private static final String CD_FOR_CATEGORY_TITLE = TEST_FILE_DIRECTORY + "category/cd_for_category_titile.xml";
+    private static final String CD_FOR_CATEGORY_NO_TITLE = TEST_FILE_DIRECTORY + "category/cd_for_category_no_title.xml";
     private static final String TEST_TITLE = "test title";
 
     private FhirParseService fhirParseService;
@@ -123,8 +125,7 @@ public class CodeableConceptCdMapperTest {
         var condition = ResourceTestFileUtils.getFileContent(inputJson);
         var codeableConcept = fhirParseService.parseResource(condition, Condition.class).getCode();
         var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
-
-        var outputString = codeableConceptCdMapper.mapCdForTopic(codeableConcept);
+        var outputString = codeableConceptCdMapper.mapToCdForTopic(codeableConcept);
 
         assertThat(outputString)
             .describedAs(TestArgumentsLoaderUtil.FAIL_MESSAGE, inputJson, outputXml)
@@ -133,23 +134,20 @@ public class CodeableConceptCdMapperTest {
 
     @Test
     @SneakyThrows
-    public void When_MapCdForTopic_With_RelatedProblemAndTitle_Expect_ProblemCodeAndTitleAreUsed() {
+    public void When_MapToCdForTopic_With_RelatedProblemAndTitle_Expect_ProblemCodeAndTitleAreUsed() {
         var relatedProblem = ResourceTestFileUtils.getFileContent(TEST_FILE_TOPIC_RELATED_CONDITION);
         var codeableConcept = fhirParseService.parseResource(relatedProblem, Condition.class).getCode();
         var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_TOPIC_RELATED_PROBLEM_AND_TITLE);
+        var outputString = codeableConceptCdMapper.mapToCdForTopic(codeableConcept, TEST_TITLE);
 
-        var outputString = codeableConceptCdMapper.mapCdForTopic(codeableConcept, TEST_TITLE);
-
-        assertThat(outputString)
-            .isEqualToIgnoringWhitespace(expectedOutput);
+        assertThat(outputString).isEqualToIgnoringWhitespace(expectedOutput);
     }
 
     @Test
     @SneakyThrows
-    public void When_MapCdForTopic_With_TitleOnly_Expect_UnspecifiedProblemAndTitle() {
+    public void When_MapToCdForTopic_With_TitleOnly_Expect_UnspecifiedProblemAndTitle() {
         var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_TOPIC_TITLE);
-
-        var outputString = codeableConceptCdMapper.mapCdForTopic(TEST_TITLE);
+        var outputString = codeableConceptCdMapper.mapToCdForTopic(TEST_TITLE);
 
         assertThat(outputString)
             .isEqualToIgnoringWhitespace(expectedOutput);
@@ -157,12 +155,28 @@ public class CodeableConceptCdMapperTest {
 
     @Test
     @SneakyThrows
-    public void When_MapCdForTopic_Without_RelatedProblemOrTile_Expect_UnspecifiedProblem() {
+    public void When_MapToCdForTopic_Without_RelatedProblemOrTile_Expect_UnspecifiedProblem() {
         var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_TOPIC_UNSPECIFIED);
+        var outputString = codeableConceptCdMapper.getCdForTopic();
 
-        var outputString = codeableConceptCdMapper.mapCdForTopic();
+        assertThat(outputString).isEqualToIgnoringWhitespace(expectedOutput);
+    }
 
-        assertThat(outputString)
-            .isEqualToIgnoringWhitespace(expectedOutput);
+    @Test
+    @SneakyThrows
+    public void When_MapToCdForCategory_With_Title_Expect_OtherCategoryAndOriginalText() {
+        var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_CATEGORY_TITLE);
+        var outputString = codeableConceptCdMapper.mapToCdForCategory(TEST_TITLE);
+
+        assertThat(outputString).isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    @SneakyThrows
+    public void When_GetCdForCategory_Expect_OtherCategory() {
+        var expectedOutput = ResourceTestFileUtils.getFileContent(CD_FOR_CATEGORY_NO_TITLE);
+        var outputString = codeableConceptCdMapper.getCdForCategory();
+
+        assertThat(outputString).isEqualToIgnoringWhitespace(expectedOutput);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -122,6 +122,18 @@ public class EhrExtractMapperComponentTest {
             .thenCallRealMethod();
         when(codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.mapToCdForTopic(any(CodeableConcept.class)))
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.mapToCdForTopic(any(CodeableConcept.class), any(String.class)))
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.mapToCdForTopic(any(String.class)))
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.getCdForTopic())
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.mapToCdForCategory(any(String.class)))
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.getCdForCategory())
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
 
 
         messageContext = new MessageContext(randomIdGeneratorService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -162,7 +162,8 @@ public class EhrExtractMapperComponentTest {
             new DiagnosticReportMapper(
                 messageContext, specimenMapper, participantMapper, randomIdGeneratorService
             ),
-            new BloodPressureValidator()
+            new BloodPressureValidator(),
+            codeableConceptCdMapper
         );
 
         AgentDirectoryMapper agentDirectoryMapper = new AgentDirectoryMapper(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -88,6 +88,8 @@ public class EncounterComponentsMapperTest {
         when(codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(any(CodeableConcept.class),
             any(AllergyIntolerance.AllergyIntoleranceClinicalStatus.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+        when(codeableConceptCdMapper.mapCdForTopic(any(String.class)))
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         when(bloodPressureValidator.isValidBloodPressure(argThat(observation ->
             CodeableConceptMappingUtils.hasCode(observation.getCode(), List.of(
                 "bloodPressureCode1", "bloodPressureCode2", "bloodPressureCode3"
@@ -155,7 +157,8 @@ public class EncounterComponentsMapperTest {
             observationStatementMapper,
             requestStatementMapper,
             diagnosticReportMapper,
-            bloodPressureValidator
+            bloodPressureValidator,
+            codeableConceptCdMapper
         );
     }
 
@@ -217,7 +220,10 @@ public class EncounterComponentsMapperTest {
     }
 
     private String removeLineEndings(String input) {
-        return input.replace("\n", "").replace("\r", "");
+        return input
+            .replace("\n", "")
+            .replace("\r", "")
+            .replace(" ", "");
     }
 
     private Encounter extractEncounter(Bundle bundle) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -59,19 +59,25 @@ public class EncounterComponentsMapperTest {
     private static final String INPUT_BUNDLE_WITH_NON_TOPIC_CONSULTATION_LIST_ENTRY = TEST_DIRECTORY + "input-bundle-8.json";
     private static final String INPUT_BUNDLE_WITH_UNSUPPORTED_RESOURCES = TEST_DIRECTORY + "input-bundle-9-unsupported-resource.json";
     private static final String INPUT_BUNDLE_WITH_IGNORED_RESOURCE = TEST_DIRECTORY + "input-bundle-10-ignored-resource.json";
-    private static final String INPUT_BUNDLE_WITH_NON_CATEGORY_TOPIC_LIST_ENTRY = TEST_DIRECTORY + "input-bundle-11-invalid-category-list.json";
+    private static final String INPUT_BUNDLE_WITH_NON_CATEGORY_TOPIC_LIST_ENTRY = TEST_DIRECTORY
+        + "input-bundle-11-invalid-category-list.json";
     private static final String INPUT_BUNDLE_WITH_RELATED_PROBLEM_IN_TOPIC = TEST_DIRECTORY + "input-bundle-12-related-problem.json";
     private static final String EXPECTED_COMPONENTS_RELATED_PROBLEM = TEST_DIRECTORY + "expected-components-12-related-problem.xml";
-    private static final String INPUT_BUNDLE_WITH_NO_DATE_PROVIDED_IN_TOPIC = TEST_DIRECTORY + "input-bundle-13-topic-without-date.json";
-    private static final String EXPECTED_COMPONENTS_TOPIC_AVAILABILITY_DATE_MAPPED_FROM_ENCOUNTER = TEST_DIRECTORY + "expected-components-13-topic-without-date.xml";
+    private static final String INPUT_BUNDLE_WITH_NO_DATE_PROVIDED_IN_TOPIC = TEST_DIRECTORY
+        + "input-bundle-13-topic-without-date.json";
+    private static final String EXPECTED_COMPONENTS_TOPIC_AVAILABILITY_DATE_MAPPED_FROM_ENCOUNTER = TEST_DIRECTORY
+        + "expected-components-13-topic-without-date.xml";
     private static final String INPUT_BUNDLE_WITH_MISSING_TITLE_IN_CATEGORY = TEST_DIRECTORY + "input-bundle-14-category-codes.json";
     private static final String EXPECTED_COMPONENTS_WITH_CD_IN_CATEGORIES = TEST_DIRECTORY + "expected-components-14-category-codes.xml";
-    private static final String INPUT_BUNDLE_WITH_RELATED_PROBLEM_IN_TOPIC_NO_TITLE = TEST_DIRECTORY + "input-bundle-15-related-problem-no-title.json";
-    private static final String EXPECTED_COMPONENTS_RELATED_PROBLEM_NO_TITLE = TEST_DIRECTORY + "expected-components-15-related-problem-no-title.xml";
+    private static final String INPUT_BUNDLE_WITH_RELATED_PROBLEM_IN_TOPIC_NO_TITLE = TEST_DIRECTORY
+        + "input-bundle-15-related-problem-no-title.json";
+    private static final String EXPECTED_COMPONENTS_RELATED_PROBLEM_NO_TITLE = TEST_DIRECTORY
+        + "expected-components-15-related-problem-no-title.xml";
     private static final String INPUT_BUNDLE_WITH_MISSING_TITLE_IN_TOPIC = TEST_DIRECTORY + "input-bundle-16-topic-codes.json";
     private static final String EXPECTED_COMPONENTS_WITH_CD_IN_TOPICS = TEST_DIRECTORY + "expected-components-16-topic-codes.xml";
     private static final String INPUT_BUNDLE_TOPIC_NO_CATEGORIES = TEST_DIRECTORY + "input-bundle-17-topic-no-categories.json";
-    private static final String EXPECTED_COMPONENTS_TOPIC_NO_CATEGORIES = TEST_DIRECTORY + "expected-components-17-topic-no-categories.xml";
+    private static final String EXPECTED_COMPONENTS_TOPIC_NO_CATEGORIES = TEST_DIRECTORY
+        + "expected-components-17-topic-no-categories.xml";
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
@@ -244,8 +250,8 @@ public class EncounterComponentsMapperTest {
 
         assertThatThrownBy(() ->
             encounterComponentsMapper.mapComponents(encounter))
-            .hasMessageContaining("Unexpected list List/topicid1 referenced in Consultation, " +
-                "expected list to be coded as Topic (EHR)")
+            .hasMessageContaining("Unexpected list List/topicid1 referenced in Consultation, "
+                + "expected list to be coded as Topic (EHR)")
             .isInstanceOf(EhrMapperException.class);
     }
 
@@ -256,8 +262,8 @@ public class EncounterComponentsMapperTest {
 
         assertThatThrownBy(() ->
             encounterComponentsMapper.mapComponents(encounter))
-            .hasMessageContaining("Unexpected list List/category1 referenced in Topic (EHR), " +
-                "expected list to be coded as Category (EHR)")
+            .hasMessageContaining("Unexpected list List/category1 referenced in Topic (EHR), "
+                + "expected list to be coded as Category (EHR)")
             .isInstanceOf(EhrMapperException.class);
     }
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -169,7 +169,8 @@ public class EhrExtractUATTest {
             ),
             new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             new DiagnosticReportMapper(messageContext, specimenMapper, participantMapper, randomIdGeneratorService),
-            new BloodPressureValidator()
+            new BloodPressureValidator(),
+            codeableConceptCdMapper
         );
 
         AgentPersonMapper agentPersonMapper

--- a/service/src/test/resources/ehr/mapper/codeableconcept/category/cd_for_category_no_title.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/category/cd_for_category_no_title.xml
@@ -1,0 +1,2 @@
+<code code="394841004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other category">
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/category/cd_for_category_titile.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/category/cd_for_category_titile.xml
@@ -1,0 +1,3 @@
+<code code="394841004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other category">
+    <originalText>test title</originalText>
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/cd_for_topic_related_problem_and_title.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/cd_for_topic_related_problem_and_title.xml
@@ -1,0 +1,3 @@
+<code code="262944016" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Trying to conceive">
+    <originalText>test title</originalText>
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/cd_for_topic_title.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/cd_for_topic_title.xml
@@ -1,0 +1,3 @@
+<code code="394776006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified problem">
+    <originalText>test title</originalText>
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/cd_for_topic_unspecified.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/cd_for_topic_unspecified.xml
@@ -1,0 +1,2 @@
+<code code="394776006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified problem">
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/codeable_concept_snowmed_related_condtition.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/codeable_concept_snowmed_related_condtition.json
@@ -1,0 +1,108 @@
+{
+    "resourceType": "Condition",
+    "id": "0c47177a-6b4d-11ed-8591-0a69bde48cbe",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+            "valueCode": "major"
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/4b817e3a-6b4d-11ed-9767-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/52febd1c-6b4d-11ed-967a-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/7fdefbda-6b4d-11ed-8c16-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/9d29ea6a-6b4d-11ed-994e-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/b8e1782c-6b4d-11ed-83b9-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "DocumentReference/emed3-fit-note--cf84924e-6b4d-11ed-81fd-0a58a9feac02"
+            }
+        }
+    ],
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "0c47177a-6b4d-11ed-8591-0a69bde48cbe"
+        }
+    ],
+    "clinicalStatus": "active",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/condition-category",
+                    "code": "problem-list-item",
+                    "display": "Problem List Item"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "169449001",
+                "display": "Trying to conceive",
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                        "extension": [
+                            {
+                                "url": "descriptionId",
+                                "valueId": "262944016"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/d0690910-6b43-11ed-98f8-0a0382d71aaa"
+    },
+    "onsetDateTime": "2016",
+    "assertedDate": "2022-11-23T16:36:58+00:00",
+    "asserter": {
+        "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+    },
+    "note": [
+        {
+            "text": "Episode: First"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_description.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_description.json
@@ -1,0 +1,97 @@
+{
+    "resourceType": "Condition",
+    "id": "0c47177a-6b4d-11ed-8591-0a69bde48cbe",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+            "valueCode": "major"
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/4b817e3a-6b4d-11ed-9767-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/52febd1c-6b4d-11ed-967a-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/7fdefbda-6b4d-11ed-8c16-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/9d29ea6a-6b4d-11ed-994e-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/b8e1782c-6b4d-11ed-83b9-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "DocumentReference/emed3-fit-note--cf84924e-6b4d-11ed-81fd-0a58a9feac02"
+            }
+        }
+    ],
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "0c47177a-6b4d-11ed-8591-0a69bde48cbe"
+        }
+    ],
+    "clinicalStatus": "active",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/condition-category",
+                    "code": "problem-list-item",
+                    "display": "Problem List Item"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "169449001",
+                "display": "Trying to conceive"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/d0690910-6b43-11ed-98f8-0a0382d71aaa"
+    },
+    "onsetDateTime": "2016",
+    "assertedDate": "2022-11-23T16:36:58+00:00",
+    "asserter": {
+        "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+    },
+    "note": [
+        {
+            "text": "Episode: First"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_description.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_description.xml
@@ -1,0 +1,2 @@
+<code code="169449001" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Trying to conceive">
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_snomed.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_snomed.json
@@ -1,0 +1,112 @@
+{
+    "resourceType": "Condition",
+    "id": "0c47177a-6b4d-11ed-8591-0a69bde48cbe",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+            "valueCode": "major"
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/4b817e3a-6b4d-11ed-9767-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/52febd1c-6b4d-11ed-967a-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/7fdefbda-6b4d-11ed-8c16-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/9d29ea6a-6b4d-11ed-994e-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/b8e1782c-6b4d-11ed-83b9-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "DocumentReference/emed3-fit-note--cf84924e-6b4d-11ed-81fd-0a58a9feac02"
+            }
+        }
+    ],
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "0c47177a-6b4d-11ed-8591-0a69bde48cbe"
+        }
+    ],
+    "clinicalStatus": "active",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/condition-category",
+                    "code": "problem-list-item",
+                    "display": "Problem List Item"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "test-code-system",
+                "code": "169449001",
+                "display": "Trying to conceive",
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                        "extension": [
+                            {
+                                "url": "descriptionId",
+                                "valueId": "262944016"
+                            },
+                            {
+                                "url": "descriptionDisplay",
+                                "valueId": "test description"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/d0690910-6b43-11ed-98f8-0a0382d71aaa"
+    },
+    "onsetDateTime": "2016",
+    "assertedDate": "2022-11-23T16:36:58+00:00",
+    "asserter": {
+        "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+    },
+    "note": [
+        {
+            "text": "Episode: First"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_snomed.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_no_snomed.xml
@@ -1,0 +1,2 @@
+<code code="394776006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified problem">
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description.json
@@ -1,0 +1,112 @@
+{
+    "resourceType": "Condition",
+    "id": "0c47177a-6b4d-11ed-8591-0a69bde48cbe",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+            "valueCode": "major"
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/4b817e3a-6b4d-11ed-9767-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/52febd1c-6b4d-11ed-967a-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/7fdefbda-6b4d-11ed-8c16-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/9d29ea6a-6b4d-11ed-994e-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/b8e1782c-6b4d-11ed-83b9-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "DocumentReference/emed3-fit-note--cf84924e-6b4d-11ed-81fd-0a58a9feac02"
+            }
+        }
+    ],
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "0c47177a-6b4d-11ed-8591-0a69bde48cbe"
+        }
+    ],
+    "clinicalStatus": "active",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/condition-category",
+                    "code": "problem-list-item",
+                    "display": "Problem List Item"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "169449001",
+                "display": "Trying to conceive",
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                        "extension": [
+                            {
+                                "url": "descriptionId",
+                                "valueId": "262944016"
+                            },
+                            {
+                                "url": "descriptionDisplay",
+                                "valueId": "test description"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/d0690910-6b43-11ed-98f8-0a0382d71aaa"
+    },
+    "onsetDateTime": "2016",
+    "assertedDate": "2022-11-23T16:36:58+00:00",
+    "asserter": {
+        "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+    },
+    "note": [
+        {
+            "text": "Episode: First"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description.xml
@@ -1,0 +1,2 @@
+<code code="262944016" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="test description">
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description_id_only.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description_id_only.json
@@ -1,0 +1,108 @@
+{
+    "resourceType": "Condition",
+    "id": "0c47177a-6b4d-11ed-8591-0a69bde48cbe",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+            "valueCode": "major"
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/4b817e3a-6b4d-11ed-9767-0a58a9feac02"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/52febd1c-6b4d-11ed-967a-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/7fdefbda-6b4d-11ed-8c16-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/9d29ea6a-6b4d-11ed-994e-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "Observation/b8e1782c-6b4d-11ed-83b9-0a69bde48cbe"
+            }
+        },
+        {
+            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+            "valueReference": {
+                "reference": "DocumentReference/emed3-fit-note--cf84924e-6b4d-11ed-81fd-0a58a9feac02"
+            }
+        }
+    ],
+    "identifier": [
+        {
+            "system": "https://medicus.health",
+            "value": "0c47177a-6b4d-11ed-8591-0a69bde48cbe"
+        }
+    ],
+    "clinicalStatus": "active",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/condition-category",
+                    "code": "problem-list-item",
+                    "display": "Problem List Item"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "169449001",
+                "display": "Trying to conceive",
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                        "extension": [
+                            {
+                                "url": "descriptionId",
+                                "valueId": "262944016"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/d0690910-6b43-11ed-98f8-0a0382d71aaa"
+    },
+    "onsetDateTime": "2016",
+    "assertedDate": "2022-11-23T16:36:58+00:00",
+    "asserter": {
+        "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+    },
+    "note": [
+        {
+            "text": "Episode: First"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description_id_only.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/topic/relatedProblem/codeable_concept_topic_with_description_id_only.xml
@@ -1,0 +1,2 @@
+<code code="262944016" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Trying to conceive">
+</code>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
@@ -1,577 +1,719 @@
-<component typeCode="COMP" >
-    <PlanStatement classCode="OBS" moodCode="INT">
-        <id root="394559384658936" />
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center nullFlavor="UNK"/>
-        </effectiveTime>
-        <availabilityTime value="20100113152950"/>
-    </PlanStatement>
-</component><component typeCode="COMP" >
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936" />
-        <text>observation comment</text>
-        <statusCode code="COMPLETE" />
-        <availabilityTime value="20100113152950" />
-    </NarrativeStatement>
-</component><component typeCode="COMP">
-    <LinkSet classCode="OBS" moodCode="EVN">
-        <id root="394559384658936" />
-        <code code="394774009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Active Problem">
-            <originalText>Active Problem, minor</originalText>
-            <qualifier inverted="false">
-                <name code="394847000" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified significance"/>
-            </qualifier>
-        </code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <low value="20200906"/>
-            <high value="20201004000000"/>
-        </effectiveTime>
-        <availabilityTime value="20200907101202" />
-            <component typeCode="COMP">
-                <statementRef classCode="OBS" moodCode="EVN">
-                    <id root="394559384658936"/>
-                </statementRef>
-            </component>
-            <component typeCode="COMP">
-                <statementRef classCode="OBS" moodCode="EVN">
-                    <id root="394559384658936"/>
-                </statementRef>
-            </component>
-            <component typeCode="COMP">
-                <statementRef classCode="OBS" moodCode="EVN">
-                    <id root="394559384658936"/>
-                </statementRef>
-            </component>
-        <conditionNamed typeCode="NAME" inversionInd="true">
-            <namedStatementRef classCode="OBS" moodCode="EVN">
-                <id root="394559384658936"/>
-            </namedStatementRef>
-        </conditionNamed>
-        <Participant typeCode="PRF" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="394559384658936"/>
-    </agentRef>
-</Participant>
-    </LinkSet>
-</component>
-<component typeCode="COMP" >
-    <ObservationStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936" />
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center value="20100630055900"/>
-        </effectiveTime>
-        <availabilityTime value="20100630055900" />
-        <pertinentInformation typeCode="PERT">
-            <sequenceNumber value="+1"/>
-            <pertinentAnnotation classCode="OBS" moodCode="EVN">
-                <text>Primary Source: true immunization note</text>
-            </pertinentAnnotation>
-        </pertinentInformation>
-        <Participant typeCode="PRF" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="394559384658936"/>
-    </agentRef>
-</Participant>
-    </ObservationStatement>
-</component>
-<component typeCode="COMP" >
-    <ObservationStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936" />
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center nullFlavor="UNK"/>
-        </effectiveTime>
-        <availabilityTime nullFlavor="UNK"/>
-        
-        
-        <pertinentInformation typeCode="PERT">
-            <sequenceNumber value="+1" />
-            <pertinentAnnotation classCode="OBS" moodCode="EVN">
-                <text>observation uncategorised</text>
-            </pertinentAnnotation>
-        </pertinentInformation>
-        
-    </ObservationStatement>
-</component><component typeCode="COMP">
-    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
         <id root="394559384658936"/>
         <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
         <statusCode code="COMPLETE"/>
         <effectiveTime>
-            <center nullFlavor="UNK"/>
+            <low value="20100113152000"/><high value="20100113162000"/>
         </effectiveTime>
-        <availabilityTime nullFlavor="UNK"/>
+        <availabilityTime value="20100123140354"/>
+
         <component typeCode="COMP" contextConductionInd="true">
-            <NarrativeStatement classCode="OBS" moodCode="EVN">
-                <id root="394559384658936"/>
-                <text>Blood pressure 1</text>
-                <statusCode code="COMPLETE"/>
-                <availabilityTime nullFlavor="UNK"/>
-            </NarrativeStatement>
-        </component>
-    </CompoundStatement>
-</component><component typeCode="COMP">
-    <CompoundStatement classCode="BATTERY" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="UNK"/>
-        </effectiveTime>
-        <availabilityTime nullFlavor="UNK"/>
-        <component typeCode="COMP" contextConductionInd="true">
-            <NarrativeStatement classCode="OBS" moodCode="EVN">
-                <id root="394559384658936"/>
-                <text>Blood pressure 2</text>
-                <statusCode code="COMPLETE"/>
-                <availabilityTime nullFlavor="UNK"/>
-            </NarrativeStatement>
-        </component>
-    </CompoundStatement>
-</component><component typeCode="COMP">
-    <CompoundStatement classCode="BATTERY" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="UNK"/>
-        </effectiveTime>
-        <availabilityTime nullFlavor="UNK"/>
-        <component typeCode="COMP" contextConductionInd="true">
-            <NarrativeStatement classCode="OBS" moodCode="EVN">
-                <id root="394559384658936"/>
-                <text>Blood pressure 3</text>
-                <statusCode code="COMPLETE"/>
-                <availabilityTime nullFlavor="UNK"/>
-            </NarrativeStatement>
-        </component>
-    </CompoundStatement>
-</component><component typeCode="COMP">
-    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code code="14L..00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O: drug allergy"/>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="19781231"/>
-        </effectiveTime>
-        <availabilityTime value="19781231" />
-        <component typeCode="COMP" contextConductionInd="true">
-            <ObservationStatement classCode="OBS" moodCode="ENV">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
                 <statusCode code="COMPLETE"/>
                 <effectiveTime>
-                    <center value="19781231"/>
+                    <low value="20100113152000"/><high value="20100113162000"/>
                 </effectiveTime>
-                <availabilityTime value="19781231" />
+                <availabilityTime value="20100714163232"/>
+
+                <component typeCode="COMP">
+                    <PlanStatement classCode="OBS" moodCode="INT">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center nullFlavor="UNK"/>
+                        </effectiveTime>
+                        <availabilityTime value="20100113152950"/>
+                    </PlanStatement>
+                </component>
+
+                <component typeCode="COMP">
+                    <NarrativeStatement classCode="OBS" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <text>observation comment</text>
+                        <statusCode code="COMPLETE"/>
+                        <availabilityTime value="20100113152950"/>
+                    </NarrativeStatement>
+                </component>
+
+                <component typeCode="COMP">
+                    <LinkSet classCode="OBS" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="394774009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Active Problem">
+                            <originalText>Active Problem, minor</originalText>
+                            <qualifier inverted="false">
+                                <name code="394847000" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified significance"/>
+                            </qualifier>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <low value="20200906"/>
+                            <high value="20201004000000"/>
+                        </effectiveTime>
+                        <availabilityTime value="20200907101202"/>
+                        <component typeCode="COMP">
+                            <statementRef classCode="OBS" moodCode="EVN">
+                                <id root="394559384658936"/>
+                            </statementRef>
+                        </component>
+                        <component typeCode="COMP">
+                            <statementRef classCode="OBS" moodCode="EVN">
+                                <id root="394559384658936"/>
+                            </statementRef>
+                        </component>
+                        <component typeCode="COMP">
+                            <statementRef classCode="OBS" moodCode="EVN">
+                                <id root="394559384658936"/>
+                            </statementRef>
+                        </component>
+                        <conditionNamed typeCode="NAME" inversionInd="true">
+                            <namedStatementRef classCode="OBS" moodCode="EVN">
+                                <id root="394559384658936"/>
+                            </namedStatementRef>
+                        </conditionNamed>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                    </LinkSet>
+                </component>
+
+            </CompoundStatement>
+        </component>
+
+        <component typeCode="COMP">
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20100630055900"/>
+                </effectiveTime>
+                <availabilityTime value="20100630055900"/>
                 <pertinentInformation typeCode="PERT">
                     <sequenceNumber value="+1"/>
                     <pertinentAnnotation classCode="OBS" moodCode="EVN">
-                        <text>Reason Ended: Patient reports no subsequent recurrence on same medication Status: Resolved Type: Allergy Criticality: Low Risk Last Occurred: 1978-12-31 Example note text</text>
+                        <text>Primary Source: true immunization note</text>
                     </pertinentAnnotation>
                 </pertinentInformation>
+                <Participant typeCode="PRF" contextControlCode="OP">
+                    <agentRef classCode="AGNT">
+                        <id root="394559384658936"/>
+                    </agentRef>
+                </Participant>
             </ObservationStatement>
         </component>
-    </CompoundStatement>
-</component><component typeCode="COMP" >
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936" />
-        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent Attachment: some title Setting: Practice Setting Text</text>
-        <statusCode code="COMPLETE" />
-        <availabilityTime value="20200921" />
-        <Participant typeCode="PRF" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="394559384658936"/>
-    </agentRef>
-</Participant>
-        <reference typeCode="REFR">
-            <referredToExternalDocument classCode="DOC" moodCode="EVN">
-                <id root="394559384658936"/>
-                <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/plain">
-                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
-                </text>
-            </referredToExternalDocument>
-        </reference>
-    </NarrativeStatement>
-</component><component typeCode="COMP">
-    <MedicationStatement classCode="SBADM" moodCode="ORD">
-        <id root="394559384658936"/>
-        <statusCode code="ACTIVE"/>
-        <effectiveTime>
-            <low value="20171110000000"/><high value="20180815000000"/>
-        </effectiveTime>
-        <availabilityTime value="20171110000000"/>
-        <consumable typeCode="CSM">
-            <manufacturedProduct classCode="MANU">
-                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
-                    <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-                </manufacturedMaterial>
-            </manufacturedProduct>
-        </consumable>
-        <component typeCode="COMP">
-            <ehrSupplyPrescribe>
-                <id root="394559384658936"/>
-                <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-                <statusCode code="ACTIVE"/>
-                <availabilityTime value="20171110000000"/>
-                <quantity value="1" unit="1">
-                    <translation value="1">
-                        <originalText>Unk UoM</originalText>
-                    </translation>
-                </quantity>
-                <inFulfillmentOf typeCode="FLFS">
-    <priorMedicationRef moodCode="INT">
-        <id root="394559384658936"/>
-    </priorMedicationRef>
-</inFulfillmentOf>
-                <pertinentInformation typeCode="PERT">
-                    <pertinentSupplyAnnotation>
-                        <text>Patient Instruction: Take in morning</text>
-                    </pertinentSupplyAnnotation>
-                </pertinentInformation>
-            </ehrSupplyPrescribe>
-        </component>
-        <pertinentInformation typeCode="PERT">
-            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
-                <text>1 tablet once a day</text>
-            </pertinentMedicationDosage>
-        </pertinentInformation>
-        <Participant typeCode="AUT" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="394559384658936"/>
-    </agentRef>
-</Participant>
-    </MedicationStatement>
-</component><component typeCode="COMP" >
-    <RequestStatement classCode="OBS" moodCode="RQO">
-        <id root="394559384658936" />
-        <code code="3457005" displayName="Patient referral" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-        <text>UBRN: bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4 Specialty: unknown Referred for investigation into low blood pressure</text>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20100119"/>
-        <priorityCode code="394848005" displayName="Normal" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"><originalText>Routine</originalText></priorityCode>
-    </RequestStatement>
-</component><component typeCode="COMP">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
-            <originalText>Filed Report</originalText>
-        </code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20100225154100"/>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
-CommentDate:20100225154100
 
-Status: unknown</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100225154100
-
-Filing Date: 2020-12-15 15:17:04</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100225154100
-
-Participants: Dr David McAvenue</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100225154100
-
-(q) - Normal - No Action</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component>
-<component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100225154100
-
-(q) - Normal - No Action</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component>
-<component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100225154100
-
-(q) - Normal - No Action</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20100225154100"/>
-        <specimen typeCode="SPC">
-            <specimenRole classCode="SPEC">
-                <id root="394559384658936"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DN"/>
-                <effectiveTime>
-                    <center value="20100223000000"/>
-                </effectiveTime>
-                <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
-                    <desc>URINE</desc>
-                </specimenSpecimenMaterial>
-            </specimenRole>
-        </specimen>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
-CommentDate:20100223000000
-
-Received Date: 2010-02-24 15:41
-</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="20100223"/>
-        </effectiveTime>
-        <availabilityTime value="20100223"/>
-            <component typeCode="COMP" contextConductionInd="true">
-    <ObservationStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="20100223"/>
-        </effectiveTime>
-        <availabilityTime value="20100223"/>
-    </ObservationStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100223
-
-NEGATIVE
-     In normal pregnancies the test will usually be positive from the
-     second day after the expected menstruation.</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100223"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
-CommentDate:20201215151704
-
-(q) - Normal - No Action</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20201215151704"/>
-    </NarrativeStatement>
-</component>
     </CompoundStatement>
 </component>
-    </CompoundStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20100225154100"/>
-        <specimen typeCode="SPC">
-            <specimenRole classCode="SPEC">
-                <id root="394559384658936"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DO"/>
-                <effectiveTime>
-                    <center value="20100223154100"/>
-                </effectiveTime>
-                <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
-                    <desc>SERUM</desc>
-                </specimenSpecimenMaterial>
-            </specimenRole>
-        </specimen>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
-CommentDate:20100223154100
 
-Received Date: 2001-03-30 11:21
-</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="20100223"/>
-        </effectiveTime>
-        <availabilityTime value="20100223"/>
-            <component typeCode="COMP" contextConductionInd="true">
-    <ObservationStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="20100223"/>
-        </effectiveTime>
-        <availabilityTime value="20100223"/>
-            <value xsi:type="PQ" value="8.800" unit="1"><translation value="8.800"><originalText>mmol/L</originalText></translation></value>
-            <referenceRange typeCode="REFV">
-    <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">
-        <value><low value="10.000"/><high value="90.000"/></value>
-    </referenceInterpretationRange>
-</referenceRange>
 
-    </ObservationStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
-CommentDate:20201215151713
+<component typeCode="COMP">
+<CompoundStatement classCode="TOPIC" moodCode="EVN">
+    <id root="394559384658936"/>
+    <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <low value="20100113152000"/><high value="20100113162000"/>
+    </effectiveTime>
+    <availabilityTime value="20100123140354"/>
 
-(q) - Normal - No Action</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20201215151713"/>
-    </NarrativeStatement>
-</component>
-    </CompoundStatement>
-</component>
-    </CompoundStatement>
-</component><component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20100225154100"/>
-        <specimen typeCode="SPC">
-            <specimenRole classCode="SPEC">
-                <id root="394559384658936"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DP"/>
-                <effectiveTime>
-                    <center value="20100224154100"/>
-                </effectiveTime>
-                <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
-                    <desc>SERUM</desc>
-                </specimenSpecimenMaterial>
-            </specimenRole>
-        </specimen>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
-CommentDate:20100224154100
+    <component typeCode="COMP" contextConductionInd="true">
+        <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+            <id root="394559384658936"/>
+            <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+            <statusCode code="COMPLETE"/>
+            <effectiveTime>
+                <low value="20100113152000"/><high value="20100113162000"/>
+            </effectiveTime>
+            <availabilityTime value="20100714163232"/>
 
-Received Date: 2010-02-24 15:41
-</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100225154100"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="20100223"/>
-        </effectiveTime>
-        <availabilityTime value="20100223"/>
-            <component typeCode="COMP" contextConductionInd="true">
-    <ObservationStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center value="20100223"/>
-        </effectiveTime>
-        <availabilityTime value="20100223"/>
-    </ObservationStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:20100223
+            <component typeCode="COMP">
+                <ObservationStatement classCode="OBS" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <code nullFlavor="UNK">
+                        <originalText>Mocked code</originalText>
+                    </code>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="UNK"/>
+                    </effectiveTime>
+                    <availabilityTime nullFlavor="UNK"/>
 
-Test not available</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100223"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="394559384658936"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
-CommentDate:20201215151713
 
-(q) - Normal - No Action</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20201215151713"/>
-    </NarrativeStatement>
-</component>
-    </CompoundStatement>
-</component>
-    </CompoundStatement>
-</component>
-            <Participant typeCode="AUT" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="394559384658936"/>
-    </agentRef>
-</Participant>
-    </CompoundStatement>
+                    <pertinentInformation typeCode="PERT">
+                        <sequenceNumber value="+1"/>
+                        <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                            <text>observation uncategorised</text>
+                        </pertinentAnnotation>
+                    </pertinentInformation>
+
+                </ObservationStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <code nullFlavor="UNK">
+                        <originalText>Mocked code</originalText>
+                    </code>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="UNK"/>
+                    </effectiveTime>
+                    <availabilityTime nullFlavor="UNK"/>
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text>Blood pressure 1</text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime nullFlavor="UNK"/>
+                        </NarrativeStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <code nullFlavor="UNK">
+                        <originalText>Mocked code</originalText>
+                    </code>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="UNK"/>
+                    </effectiveTime>
+                    <availabilityTime nullFlavor="UNK"/>
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text>Blood pressure 2</text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime nullFlavor="UNK"/>
+                        </NarrativeStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <CompoundStatement classCode="BATTERY" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <code nullFlavor="UNK">
+                        <originalText>Mocked code</originalText>
+                    </code>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="UNK"/>
+                    </effectiveTime>
+                    <availabilityTime nullFlavor="UNK"/>
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text>Blood pressure 3</text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime nullFlavor="UNK"/>
+                        </NarrativeStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <code code="14L..00"codeSystem="2.16.840.1.113883.2.1.6.2" displayName="H/O:drugallergy"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center value="19781231"/>
+                    </effectiveTime>
+                    <availabilityTime value="19781231"/>
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <ObservationStatement classCode="OBS" moodCode="ENV">
+                            <id root="394559384658936"/>
+                            <code nullFlavor="UNK">
+                                <originalText>Mocked code</originalText>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center value="19781231"/>
+                            </effectiveTime>
+                            <availabilityTime value="19781231"/>
+                            <pertinentInformation typeCode="PERT">
+                                <sequenceNumber value="+1"/>
+                                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                    <text>Reason Ended: Patient reports no subsequent recurrence on same medication Status: Resolved
+                                        Type: Allergy Criticality: Low Risk Last Occurred: 1978-12-31 Example note text
+                                    </text>
+                                </pertinentAnnotation>
+                            </pertinentInformation>
+                        </ObservationStatement>
+                    </component>
+                </CompoundStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <NarrativeStatement classCode="OBS" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent Attachment: some title
+                        Setting: Practice Setting Text
+                    </text>
+                    <statusCode code="COMPLETE"/>
+                    <availabilityTime value="20200921"/>
+                    <Participant typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="394559384658936"/>
+                        </agentRef>
+                    </Participant>
+                    <reference typeCode="REFR">
+                        <referredToExternalDocument classCode="DOC" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
+                            <text mediaType="text/plain">
+                                <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                            </text>
+                        </referredToExternalDocument>
+                    </reference>
+                </NarrativeStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <MedicationStatement classCode="SBADM" moodCode="ORD">
+                    <id root="394559384658936"/>
+                    <statusCode code="ACTIVE"/>
+                    <effectiveTime>
+                        <low value="20171110000000"/>
+                        <high value="20180815000000"/>
+                    </effectiveTime>
+                    <availabilityTime value="20171110000000"/>
+                    <consumable typeCode="CSM">
+                        <manufacturedProduct classCode="MANU">
+                            <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                                <code nullFlavor="UNK">
+                                    <originalText>Mocked code</originalText>
+                                </code>
+                            </manufacturedMaterial>
+                        </manufacturedProduct>
+                    </consumable>
+                    <component typeCode="COMP">
+                        <ehrSupplyPrescribe>
+                            <id root="394559384658936"/>
+                            <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                            <statusCode code="ACTIVE"/>
+                            <availabilityTime value="20171110000000"/>
+                            <quantity value="1" unit="1">
+                                <translation value="1">
+                                    <originalText>Unk UoM</originalText>
+                                </translation>
+                            </quantity>
+                            <inFulfillmentOf typeCode="FLFS">
+                                <priorMedicationRef moodCode="INT">
+                                    <id root="394559384658936"/>
+                                </priorMedicationRef>
+                            </inFulfillmentOf>
+                            <pertinentInformation typeCode="PERT">
+                                <pertinentSupplyAnnotation>
+                                    <text>Patient Instruction: Take in morning</text>
+                                </pertinentSupplyAnnotation>
+                            </pertinentInformation>
+                        </ehrSupplyPrescribe>
+                    </component>
+                    <pertinentInformation typeCode="PERT">
+                        <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                            <text>1 tablet once a day</text>
+                        </pertinentMedicationDosage>
+                    </pertinentInformation>
+                    <Participant typeCode="AUT" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="394559384658936"/>
+                        </agentRef>
+                    </Participant>
+                </MedicationStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <RequestStatement classCode="OBS" moodCode="RQO">
+                    <id root="394559384658936"/>
+                    <code code="3457005" displayName="Patient referral" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                    <text>UBRN: bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4 Specialty: unknown Referred for investigation into low blood
+                        pressure
+                    </text>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="20100119"/>
+                    <priorityCode code="394848005" displayName="Normal" codeSystem="2.16.840.1.113883.2.1.3.2.4.15">
+                        <originalText>Routine</originalText>
+                    </priorityCode>
+                </RequestStatement>
+            </component>
+
+            <component typeCode="COMP">
+                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                    <id root="394559384658936"/>
+                    <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
+                        <originalText>Filed Report</originalText>
+                    </code>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="NI"/>
+                    </effectiveTime>
+                    <availabilityTime value="20100225154100"/>
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
+                                CommentDate:20100225154100
+
+                                Status: unknown
+                            </text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100225154100"/>
+                        </NarrativeStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                CommentDate:20100225154100
+
+                                Filing Date: 2020-12-15 15:17:04
+                            </text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100225154100"/>
+                        </NarrativeStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                CommentDate:20100225154100
+
+                                Participants: Dr David McAvenue
+                            </text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100225154100"/>
+                        </NarrativeStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                CommentDate:20100225154100
+
+                                (q) - Normal - No Action
+                            </text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100225154100"/>
+                        </NarrativeStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                CommentDate:20100225154100
+
+                                (q) - Normal - No Action
+                            </text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100225154100"/>
+                        </NarrativeStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                CommentDate:20100225154100
+
+                                (q) - Normal - No Action
+                            </text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100225154100"/>
+                        </NarrativeStatement>
+                    </component>
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100225154100"/>
+                            <specimen typeCode="SPC">
+                                <specimenRole classCode="SPEC">
+                                    <id root="394559384658936"/>
+                                    <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DN"/>
+                                    <effectiveTime>
+                                        <center value="20100223000000"/>
+                                    </effectiveTime>
+                                    <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
+                                        <desc>URINE</desc>
+                                    </specimenSpecimenMaterial>
+                                </specimenRole>
+                            </specimen>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                    <id root="394559384658936"/>
+                                    <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
+                                        CommentDate:20100223000000
+
+                                        Received Date: 2010-02-24 15:41
+                                    </text>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20100225154100"/>
+                                </NarrativeStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                    <id root="394559384658936"/>
+                                    <code nullFlavor="UNK">
+                                        <originalText>Mocked code</originalText>
+                                    </code>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center value="20100223"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100223"/>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <ObservationStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <code nullFlavor="UNK">
+                                                <originalText>Mocked code</originalText>
+                                            </code>
+                                            <statusCode code="COMPLETE"/>
+                                            <effectiveTime>
+                                                <center value="20100223"/>
+                                            </effectiveTime>
+                                            <availabilityTime value="20100223"/>
+                                        </ObservationStatement>
+                                    </component>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                                CommentDate:20100223
+
+                                                NEGATIVE
+                                                In normal pregnancies the test will usually be positive from the
+                                                second day after the expected menstruation.
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20100223"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
+                                                CommentDate:20201215151704
+
+                                                (q) - Normal - No Action
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20201215151704"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100225154100"/>
+                            <specimen typeCode="SPC">
+                                <specimenRole classCode="SPEC">
+                                    <id root="394559384658936"/>
+                                    <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DO"/>
+                                    <effectiveTime>
+                                        <center value="20100223154100"/>
+                                    </effectiveTime>
+                                    <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
+                                        <desc>SERUM</desc>
+                                    </specimenSpecimenMaterial>
+                                </specimenRole>
+                            </specimen>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                    <id root="394559384658936"/>
+                                    <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
+                                        CommentDate:20100223154100
+
+                                        Received Date: 2001-03-30 11:21
+                                    </text>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20100225154100"/>
+                                </NarrativeStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                    <id root="394559384658936"/>
+                                    <code nullFlavor="UNK">
+                                        <originalText>Mocked code</originalText>
+                                    </code>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center value="20100223"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100223"/>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <ObservationStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <code nullFlavor="UNK">
+                                                <originalText>Mocked code</originalText>
+                                            </code>
+                                            <statusCode code="COMPLETE"/>
+                                            <effectiveTime>
+                                                <center value="20100223"/>
+                                            </effectiveTime>
+                                            <availabilityTime value="20100223"/>
+                                            <value xsi:type="PQ" value="8.800" unit="1">
+                                                <translation value="8.800">
+                                                    <originalText>mmol/L</originalText>
+                                                </translation>
+                                            </value>
+                                            <referenceRange typeCode="REFV">
+                                                <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">
+                                                    <value>
+                                                        <low value="10.000"/>
+                                                        <high value="90.000"/>
+                                                    </value>
+                                                </referenceInterpretationRange>
+                                            </referenceRange>
+
+                                        </ObservationStatement>
+                                    </component>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
+                                                CommentDate:20201215151713
+
+                                                (q) - Normal - No Action
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20201215151713"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+
+                    <component typeCode="COMP" contextConductionInd="true">
+                        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                            <id root="394559384658936"/>
+                            <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20100225154100"/>
+                            <specimen typeCode="SPC">
+                                <specimenRole classCode="SPEC">
+                                    <id root="394559384658936"/>
+                                    <id root="2.16.840.1.113883.2.1.4.5.2" extension="CH000056DP"/>
+                                    <effectiveTime>
+                                        <center value="20100224154100"/>
+                                    </effectiveTime>
+                                    <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
+                                        <desc>SERUM</desc>
+                                    </specimenSpecimenMaterial>
+                                </specimenRole>
+                            </specimen>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                    <id root="394559384658936"/>
+                                    <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
+                                        CommentDate:20100224154100
+
+                                        Received Date: 2010-02-24 15:41
+                                    </text>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20100225154100"/>
+                                </NarrativeStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                    <id root="394559384658936"/>
+                                    <code nullFlavor="UNK">
+                                        <originalText>Mocked code</originalText>
+                                    </code>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center value="20100223"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20100223"/>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <ObservationStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <code nullFlavor="UNK">
+                                                <originalText>Mocked code</originalText>
+                                            </code>
+                                            <statusCode code="COMPLETE"/>
+                                            <effectiveTime>
+                                                <center value="20100223"/>
+                                            </effectiveTime>
+                                            <availabilityTime value="20100223"/>
+                                        </ObservationStatement>
+                                    </component>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                                CommentDate:20100223
+
+                                                Test not available
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20100223"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="394559384658936"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
+                                                CommentDate:20201215151713
+
+                                                (q) - Normal - No Action
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20201215151713"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                    <Participant typeCode="AUT" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="394559384658936"/>
+                        </agentRef>
+                    </Participant>
+                </CompoundStatement>
+            </component>
+
+        </CompoundStatement>
+    </component>
+
+</CompoundStatement>
 </component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-12-related-problem.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-12-related-problem.xml
@@ -1,7 +1,9 @@
 <component typeCode="COMP">
     <CompoundStatement classCode="TOPIC" moodCode="EVN">
         <id root="394559384658936"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <code code="1234567" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="test display">
+            <originalText>Endometriosis of uterus</originalText>
+        </code>
         <statusCode code="COMPLETE"/>
         <effectiveTime>
             <low value="20100113152000"/><high value="20100113162000"/>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-13-topic-without-date.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-13-topic-without-date.xml
@@ -1,0 +1,37 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100113152000"/><high value="20100113162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000"/>
+
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20100113152000"/><high value="20100113162000"/>
+                </effectiveTime>
+                <availabilityTime value="20100714163232"/>
+
+                <component typeCode="COMP">
+                    <PlanStatement classCode="OBS" moodCode="INT">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center nullFlavor="UNK"/>
+                        </effectiveTime>
+                        <availabilityTime value="20100113152950"/>
+                    </PlanStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-14-category-codes.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-14-category-codes.xml
@@ -1,0 +1,79 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100113152000"/><high value="20100113162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000"/>
+
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code code="394841004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other category">
+                    <originalText>History</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20100113152000"/><high value="20100113162000"/>
+                </effectiveTime>
+                <availabilityTime value="20100714163232"/>
+
+                <component typeCode="COMP">
+                    <PlanStatement classCode="OBS" moodCode="INT">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center nullFlavor="UNK"/>
+                        </effectiveTime>
+                        <availabilityTime value="20100113152950"/>
+                    </PlanStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code code="394841004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other category">
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20100113152000"/><high value="20100113162000"/>
+                </effectiveTime>
+                <availabilityTime value="20100714163232"/>
+
+                <component typeCode="COMP">
+                    <NarrativeStatement classCode="OBS" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent Attachment: some title
+                            Setting: Practice Setting Text
+                        </text>
+                        <statusCode code="COMPLETE"/>
+                        <availabilityTime value="20200921"/>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                        <reference typeCode="REFR">
+                            <referredToExternalDocument classCode="DOC" moodCode="EVN">
+                                <id root="394559384658936"/>
+                                <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
+                                <text mediaType="text/plain">
+                                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                                </text>
+                            </referredToExternalDocument>
+                        </reference>
+                    </NarrativeStatement>
+                </component>
+
+            </CompoundStatement>
+        </component>
+
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-15-related-problem-no-title.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-15-related-problem-no-title.xml
@@ -2,7 +2,6 @@
     <CompoundStatement classCode="TOPIC" moodCode="EVN">
         <id root="394559384658936"/>
         <code code="1234567" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="test display">
-            <originalText>Endometriosis of uterus</originalText>
         </code>
         <statusCode code="COMPLETE"/>
         <effectiveTime>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-16-topic-codes.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-16-topic-codes.xml
@@ -1,0 +1,100 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code code="394776006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified problem">
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100113152000"/>
+            <high value="20100113162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000"/>
+
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20100113152000"/>
+                    <high value="20100113162000"/>
+                </effectiveTime>
+                <availabilityTime value="20100714163232"/>
+
+                <component typeCode="COMP">
+                    <PlanStatement classCode="OBS" moodCode="INT">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center nullFlavor="UNK"/>
+                        </effectiveTime>
+                        <availabilityTime value="20100113152950"/>
+                    </PlanStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>
+
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code code="394776006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified problem">
+            <originalText>Test Title</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100113152000"/>
+            <high value="20100113162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000"/>
+
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20100113152000"/>
+                    <high value="20100113162000"/>
+                </effectiveTime>
+                <availabilityTime value="20100714163232"/>
+
+                <component typeCode="COMP">
+                    <NarrativeStatement classCode="OBS" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent
+                            Attachment: some title
+                            Setting: Practice Setting Text
+                        </text>
+                        <statusCode code="COMPLETE"/>
+                        <availabilityTime value="20200921"/>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                        <reference typeCode="REFR">
+                            <referredToExternalDocument classCode="DOC" moodCode="EVN">
+                                <id root="394559384658936"/>
+                                <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                      displayName="Other digital signal"/>
+                                <text mediaType="text/plain">
+                                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                                </text>
+                            </referredToExternalDocument>
+                        </reference>
+                    </NarrativeStatement>
+                </component>
+
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-17-topic-no-categories.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-17-topic-no-categories.xml
@@ -1,0 +1,28 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100113152000"/>
+            <high value="20100113162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000"/>
+
+        <component typeCode="COMP">
+            <PlanStatement classCode="OBS" moodCode="INT">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center nullFlavor="UNK"/>
+                </effectiveTime>
+                <availabilityTime value="20100113152950"/>
+            </PlanStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-11-invalid-category-list.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-11-invalid-category-list.json
@@ -1,0 +1,1551 @@
+{
+    "resourceType": "Bundle",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "List",
+                "title": "GP Surgery",
+                "id": "consultationid1",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "325851000000107",
+                            "display": "Consultation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-13T15:29:50.283+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/topicid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/topicid2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "topicid1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "title": "Endometriosis of uterus",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-23T14:03:54.347+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/category1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Immunization/immunizationid1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "topicid2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Untitled",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-23T14:03:54.347+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/category2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "category1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "111111111",
+                            "display": "Test - should produce error"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "ProcedureRequest/procedurerequestid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/observationcommentid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/conditionid1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "category2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/observationuncategorisedid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/bloodpressure1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/bloodpressure2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/bloodpressure3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "AllergyIntolerance/allergyintolerance1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "DocumentReference/documentreference1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/medicationrequest1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "ReferralRequest/referralrequest1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "DiagnosticReport/96B93E28-293D-46E7-B4C2-D477EEBF7098"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "AllergyIntolerance",
+                "id": "allergyintolerance1",
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-AllergyIntoleranceEnd-1",
+                        "extension": [
+                            {
+                                "url": "reasonEnded",
+                                "valueString": "Patient reports no subsequent recurrence on same medication"
+                            }
+                        ]
+                    }
+                ],
+                "clinicalStatus": "resolved",
+                "type": "allergy",
+                "category": [
+                    "medication"
+                ],
+                "criticality": "low",
+                "onsetDateTime": "1978-12-31",
+                "assertedDate": "2010-01-14T09:57:57.33+00:00",
+                "note": [
+                    {
+                        "text": "Example note text"
+                    }
+                ],
+                "lastOccurrence": "1978-12-31",
+                "code": {
+                    "text": "test"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "documentreference1",
+                "meta": {
+                    "versionId": "5774557612980378259",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25611000000107",
+                            "display": "Referral letter",
+                            "userSelected": true
+                        }
+                    ],
+                    "text": "Referral Letter (21-Sep-2020)"
+                },
+                "created": "2020-09-21",
+                "indexed": "2020-09-21T14:17:59.607+01:00",
+                "custodian": {
+                    "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "text/richtext",
+                            "title": "some title"
+                        }
+                    }
+                ],
+                "description": "for 2 week rule referral - skin",
+                "author": [
+                    {
+                        "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "context": {
+                    "practiceSetting": {
+                        "coding": [
+                            {
+                                "display": "Practice Setting Display"
+                            }
+                        ],
+                        "text": "Practice Setting Text"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Immunization",
+                "id": "immunizationid1",
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-DateRecorded-1",
+                        "valueDateTime": "2010-06-30T05:48:06.91+01:00"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-VaccinationProcedure-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "http://read.info/readv2",
+                                    "code": "65M1.00",
+                                    "display": "Measles/mumps/rubella vaccn.",
+                                    "userSelected": true
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "descriptionId",
+                                                    "valueId": "65004017"
+                                                },
+                                                {
+                                                    "url": "descriptionDisplay",
+                                                    "valueString": "Measles-mumps-rubella vaccination"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "38598009",
+                                    "display": "Measles-mumps-rubella vaccination"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "C93659E1-1107-441C-BE25-C5EF4B7831D1"
+                    }
+                ],
+                "status": "completed",
+                "notGiven": false,
+                "vaccineCode": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/NullFlavor",
+                            "code": "UNK",
+                            "display": "unknown"
+                        }
+                    ]
+                },
+                "patient": {
+                    "reference": "Patient/58B02021-E70A-4B30-A149-A02E3A5296C7"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-06-30T05:59:00+01:00",
+                "primarySource": true,
+                "practitioner": [
+                    {
+                        "role": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/v2/0443",
+                                    "code": "AP",
+                                    "display": "Administering Provider"
+                                }
+                            ]
+                        },
+                        "actor": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "note": [
+                    {
+                        "text": "immunization note"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType":"MedicationRequest",
+                "id":"medicationrequest1",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension":[
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 11
+                            }
+                        ]
+                    }
+                ],
+                "identifier":[
+                    {
+                        "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+                    }
+                ],
+                "status":"active",
+                "intent":"order",
+                "medicationReference":{
+                    "reference":"Medication/20"
+                },
+                "subject":{
+                    "reference":"Patient/2"
+                },
+                "authoredOn":"2017-11-10T00:00:00+00:00",
+                "recorder":{
+                    "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "dosageInstruction":[
+                    {
+                        "text":"1 tablet once a day",
+                        "patientInstruction":"Take in morning"
+                    }
+                ],
+                "dispenseRequest":{
+                    "validityPeriod":{
+                        "start":"2017-11-10T00:00:00+00:00",
+                        "end":"2018-08-15T00:00:00+01:00"
+                    }
+                },
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/medicationrequest2"
+                    }
+                ]
+            }
+
+        },
+        {
+            "resource": {
+                "resourceType":"MedicationRequest",
+                "id":"medicationrequest2",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valueUnsignedInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valueUnsignedInt": 0
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatusReason-1",
+                        "extension": [
+                            {
+                                "url": "statusReason",
+                                "valueCodeableConcept": {
+                                    "text": "Clinical Contra-indication"
+                                }
+                            },
+                            {
+                                "url": "statusChangeDate",
+                                "valueDateTime": "2010-01-18T14:33:16.397+00:00"
+                            }
+                        ]
+                    }
+                ],
+                "identifier":[
+                    {
+                        "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+                    }
+                ],
+                "groupIdentifier":{
+                    "value":"M-3"
+                },
+                "status":"active",
+                "intent":"plan",
+                "medicationReference":{
+                    "reference":"Medication/20"
+                },
+                "subject":{
+                    "reference":"Patient/2"
+                },
+                "authoredOn":"2017-11-10T00:00:00+00:00",
+                "recorder":{
+                    "reference":"Practitioner/1"
+                },
+                "dosageInstruction":[
+                    {
+                        "text":"1 tablet once a day",
+                        "patientInstruction":"Take in morning"
+                    }
+                ],
+                "dispenseRequest":{
+                    "validityPeriod":{
+                        "start":"2017-11-10T00:00:00+00:00",
+                        "end":"2018-08-15T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "value": 100,
+                        "unit": "device"
+                    },
+                    "expectedSupplyDuration":{
+                        "value":28,
+                        "unit":"day",
+                        "system":"http://unitsofmeasure.org",
+                        "code":"d"
+                    },
+                    "performer":{
+                        "reference":"Organization/1"
+                    }
+                },
+                "note": [
+                    {
+                        "text": "Example note text 1"
+                    },
+                    {
+                        "text": "Example note text 2"
+                    },
+                    {
+                        "text": "Example note text 3"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "20",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "430127000",
+                            "display": "Oral Form Oxycodone (product)"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "referralrequest1",
+                "authoredOn": "2010-01-19",
+                "priority": "routine",
+                "description": "Referred for investigation into low blood pressure",
+                "specialty": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/NullFlavor",
+                            "code": "UNK",
+                            "display": "unknown"
+                        }
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+                    },
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ubr-number",
+                        "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ProcedureRequest",
+                "id": "procedurerequestid1",
+                "status": "active",
+                "intent": "plan",
+                "authoredOn": "2010-01-13T15:29:50.1+00:00",
+                "code": {
+                    "text": "test"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "observationcommentid1",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100"
+                        }
+                    ]
+                },
+                "issued": "2010-01-13T15:29:50.3+00:00",
+                "comment": "observation comment"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "observationuncategorisedid1",
+                "code": {
+                    "text": "Test"
+                },
+                "issued": "2010-01-13T15:29:50.3+00:00",
+                "comment": "observation uncategorised"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Flag",
+                "id": "flagid1",
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "F550CC56-EF65-4934-A7B1-3DC2E02243C3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "text": "GP Surgery"
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/v3/ParticipationType",
+                                        "code": "PPRF",
+                                        "display": "primary performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2010-01-13T15:20:00+00:00",
+                    "end": "2010-01-13T16:20:00+00:00"
+                },
+                "location": [
+                    {
+                        "location": {
+                            "reference": "Location/EB3994A6-5A87-4B53-A414-913137072F57"
+                        }
+                    }
+                ],
+                "serviceProvider": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "conditionid1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
+                        "valueReference": {
+                            "reference": "Observation/7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "ReferralRequest/D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "ReferralRequest/82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "DocumentReference/8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "minor"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "onsetDateTime": "2020-09-06",
+                "abatementDateTime": "2020-10-04T00:00:00+01:00",
+                "assertedDate": "2020-09-07T10:12:02.093+01:00",
+                "asserter": {
+                    "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "note": [
+                    {
+                        "text": "Condition note"
+                    }
+                ],
+                "code": {
+                    "text": "test"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "bloodpressure1",
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "42Q5.00",
+                            "display": "Prothrombin time",
+                            "userSelected": true
+                        },
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "bloodPressureCode1"
+                        }
+                    ]
+                },
+                "comment": "Blood pressure 1"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "bloodpressure3",
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "42Q5.00",
+                            "display": "Prothrombin time",
+                            "userSelected": true
+                        },
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "bloodPressureCode3"
+                        }
+                    ]
+                },
+                "comment": "Blood pressure 3"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "bloodpressure2",
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "42Q5.00",
+                            "display": "Prothrombin time",
+                            "userSelected": true
+                        },
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "bloodPressureCode2"
+                        }
+                    ]
+                },
+                "comment": "Blood pressure 2"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+                "meta": {
+                    "versionId": "4749697187075864793",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "McAvenue",
+                        "given": [
+                            "David"
+                        ],
+                        "prefix": [
+                            "Dr"
+                        ]
+                    }
+                ],
+                "gender": "male"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DiagnosticReport",
+                "id": "96B93E28-293D-46E7-B4C2-D477EEBF7098",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "96B93E28-293D-46E7-B4C2-D477EEBF7098"
+                    }
+                ],
+                "status": "unknown",
+                "category": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v2/0074",
+                            "code": "PAT",
+                            "display": "Pathology (gross & histopath, not surgical)"
+                        }
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "721981007",
+                            "display": "Diagnostic studies report"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "performer": [
+                    {
+                        "actor": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "issued": "2010-02-25T15:41:00+00:00",
+                "specimen": [
+                    {
+                        "reference": "Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+                    },
+                    {
+                        "reference": "Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1"
+                    },
+                    {
+                        "reference": "Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2"
+                    }
+                ],
+                "result": [
+                    {
+                        "reference": "Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2"
+                    },
+                    {
+                        "reference": "Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"
+                    },
+                    {
+                        "reference": "Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+                    },
+                    {
+                        "reference": "Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"
+                    },
+                    {
+                        "reference": "Observation/D0A358C9-4833-4827-B14B-E8515C25CB12"
+                    },
+                    {
+                        "reference": "Observation/D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Specimen",
+                "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+                    }
+                ],
+                "accessionIdentifier":{
+                    "value":"CH000056DN"
+                },
+                "type":{
+                    "text":"URINE"
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "receivedTime":"2010-02-24T15:41:00+00:00",
+                "collection":{
+                    "collectedDateTime":"2010-02-23T00:00:00+00:00"
+                }
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Specimen",
+                "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1"
+                    }
+                ],
+                "accessionIdentifier":{
+                    "value":"CH000056DO"
+                },
+                "type":{
+                    "text":"SERUM"
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "receivedTime":"2001-03-30T12:21:00+01:00",
+                "collection":{
+                    "collectedDateTime":"2010-02-23T15:41:00+00:00"
+                }
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Specimen",
+                "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2"
+                    }
+                ],
+                "accessionIdentifier":{
+                    "value":"CH000056DP"
+                },
+                "type":{
+                    "text":"SERUM"
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "receivedTime":"2010-02-24T15:41:00+00:00"
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2"
+                    }
+                ],
+                "status":"unknown",
+                "category":[
+                    {
+                        "coding":[
+                            {
+                                "system":"http://hl7.org/fhir/observation-category",
+                                "code":"laboratory",
+                                "display":"Laboratory"
+                            }
+                        ]
+                    }
+                ],
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://read.info/readv2",
+                            "code":"465..00",
+                            "display":"Urine pregnancy test",
+                            "userSelected":true
+                        },
+                        {
+                            "extension":[
+                                {
+                                    "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension":[
+                                        {
+                                            "url":"descriptionId",
+                                            "valueId":"2564081000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system":"http://snomed.info/sct",
+                            "code":"1003161000000106",
+                            "display":"Urine pregnancy test"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2010-02-23",
+                "issued":"2010-02-25T15:41:00+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"NEGATIVE\n     In normal pregnancies the test will usually be positive from the\n     second day after the expected menstruation.",
+                "specimen":{
+                    "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+                },
+                "related":[
+                    {
+                        "type":"has-member",
+                        "target":{
+                            "reference":"Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"
+                    }
+                ],
+                "status":"unknown",
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://snomed.info/sct",
+                            "code":"37331000000100",
+                            "display":"Comment note"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2020-12-15T15:17:04.917+00:00",
+                "issued":"2020-12-15T15:17:04.917+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"(q) - Normal - No Action",
+                "related":[
+                    {
+                        "type":"derived-from",
+                        "target":{
+                            "reference":"Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+                    }
+                ],
+                "status":"unknown",
+                "category":[
+                    {
+                        "coding":[
+                            {
+                                "system":"http://hl7.org/fhir/observation-category",
+                                "code":"laboratory",
+                                "display":"Laboratory"
+                            }
+                        ]
+                    }
+                ],
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://read.info/readv2",
+                            "code":"4465.00",
+                            "display":"Serum oestradiol level",
+                            "userSelected":true
+                        },
+                        {
+                            "extension":[
+                                {
+                                    "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension":[
+                                        {
+                                            "url":"descriptionId",
+                                            "valueId":"2551971000000110"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system":"http://snomed.info/sct",
+                            "code":"1010521000000102",
+                            "display":"Serum oestradiol level"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2010-02-23",
+                "issued":"2010-02-25T15:41:00+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "valueQuantity":{
+                    "value":8.800,
+                    "unit":"mmol/L"
+                },
+                "specimen":{
+                    "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1"
+                },
+                "referenceRange":[
+                    {
+                        "low":{
+                            "value":10.000,
+                            "unit":"mmol/L"
+                        },
+                        "high":{
+                            "value":90.000,
+                            "unit":"mmol/L"
+                        }
+                    }
+                ],
+                "related":[
+                    {
+                        "type":"has-member",
+                        "target":{
+                            "reference":"Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"
+                    }
+                ],
+                "status":"unknown",
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://snomed.info/sct",
+                            "code":"37331000000100",
+                            "display":"Comment note"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2020-12-15T15:17:13.46+00:00",
+                "issued":"2020-12-15T15:17:13.46+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"(q) - Normal - No Action",
+                "related":[
+                    {
+                        "type":"derived-from",
+                        "target":{
+                            "reference":"Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"D0A358C9-4833-4827-B14B-E8515C25CB12",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"D0A358C9-4833-4827-B14B-E8515C25CB12"
+                    }
+                ],
+                "status":"unknown",
+                "category":[
+                    {
+                        "coding":[
+                            {
+                                "system":"http://hl7.org/fhir/observation-category",
+                                "code":"laboratory",
+                                "display":"Laboratory"
+                            }
+                        ]
+                    }
+                ],
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://read.info/readv2",
+                            "code":"4483.00",
+                            "display":"Serum ACTH",
+                            "userSelected":true
+                        },
+                        {
+                            "extension":[
+                                {
+                                    "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension":[
+                                        {
+                                            "url":"descriptionId",
+                                            "valueId":"2563401000000119"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system":"http://snomed.info/sct",
+                            "code":"997201000000100",
+                            "display":"Serum ACTH (adrenocorticotrophic hormone) level"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2010-02-23",
+                "issued":"2010-02-25T15:41:00+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"Test not available",
+                "specimen":{
+                    "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2"
+                },
+                "related":[
+                    {
+                        "type":"has-member",
+                        "target":{
+                            "reference":"Observation/D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"D0A358C9-4833-4827-B14B-E8515C25CB12-COMM",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"
+                    }
+                ],
+                "status":"unknown",
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://snomed.info/sct",
+                            "code":"37331000000100",
+                            "display":"Comment note"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2020-12-15T15:17:13.51+00:00",
+                "issued":"2020-12-15T15:17:13.51+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"(q) - Normal - No Action",
+                "related":[
+                    {
+                        "type":"derived-from",
+                        "target":{
+                            "reference":"Observation/D0A358C9-4833-4827-B14B-E8515C25CB12"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+                "meta": {
+                    "versionId": "1112974926854455048",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-OrganisationType-1",
+                                "code": "gp-practice"
+                            }
+                        ],
+                        "text": "GP Practice"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-12-related-problem.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-12-related-problem.json
@@ -1,0 +1,1581 @@
+{
+    "resourceType": "Bundle",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "List",
+                "title": "GP Surgery",
+                "id": "consultationid1",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "325851000000107",
+                            "display": "Consultation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-13T15:29:50.283+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/topicid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/topicid2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "topicid1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "title": "Endometriosis of uterus",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-23T14:03:54.347+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/conditionid1"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/category1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Immunization/immunizationid1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "topicid2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Untitled",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-23T14:03:54.347+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/category2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "category1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "ProcedureRequest/procedurerequestid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/observationcommentid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/conditionid1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "category2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/observationuncategorisedid1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/bloodpressure1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/bloodpressure2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/bloodpressure3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "AllergyIntolerance/allergyintolerance1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "DocumentReference/documentreference1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/medicationrequest1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "ReferralRequest/referralrequest1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "DiagnosticReport/96B93E28-293D-46E7-B4C2-D477EEBF7098"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "AllergyIntolerance",
+                "id": "allergyintolerance1",
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-AllergyIntoleranceEnd-1",
+                        "extension": [
+                            {
+                                "url": "reasonEnded",
+                                "valueString": "Patient reports no subsequent recurrence on same medication"
+                            }
+                        ]
+                    }
+                ],
+                "clinicalStatus": "resolved",
+                "type": "allergy",
+                "category": [
+                    "medication"
+                ],
+                "criticality": "low",
+                "onsetDateTime": "1978-12-31",
+                "assertedDate": "2010-01-14T09:57:57.33+00:00",
+                "note": [
+                    {
+                        "text": "Example note text"
+                    }
+                ],
+                "lastOccurrence": "1978-12-31",
+                "code": {
+                    "text": "test"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "documentreference1",
+                "meta": {
+                    "versionId": "5774557612980378259",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25611000000107",
+                            "display": "Referral letter",
+                            "userSelected": true
+                        }
+                    ],
+                    "text": "Referral Letter (21-Sep-2020)"
+                },
+                "created": "2020-09-21",
+                "indexed": "2020-09-21T14:17:59.607+01:00",
+                "custodian": {
+                    "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "text/richtext",
+                            "title": "some title"
+                        }
+                    }
+                ],
+                "description": "for 2 week rule referral - skin",
+                "author": [
+                    {
+                        "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "context": {
+                    "practiceSetting": {
+                        "coding": [
+                            {
+                                "display": "Practice Setting Display"
+                            }
+                        ],
+                        "text": "Practice Setting Text"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Immunization",
+                "id": "immunizationid1",
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-DateRecorded-1",
+                        "valueDateTime": "2010-06-30T05:48:06.91+01:00"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-VaccinationProcedure-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "http://read.info/readv2",
+                                    "code": "65M1.00",
+                                    "display": "Measles/mumps/rubella vaccn.",
+                                    "userSelected": true
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "descriptionId",
+                                                    "valueId": "65004017"
+                                                },
+                                                {
+                                                    "url": "descriptionDisplay",
+                                                    "valueString": "Measles-mumps-rubella vaccination"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "38598009",
+                                    "display": "Measles-mumps-rubella vaccination"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "C93659E1-1107-441C-BE25-C5EF4B7831D1"
+                    }
+                ],
+                "status": "completed",
+                "notGiven": false,
+                "vaccineCode": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/NullFlavor",
+                            "code": "UNK",
+                            "display": "unknown"
+                        }
+                    ]
+                },
+                "patient": {
+                    "reference": "Patient/58B02021-E70A-4B30-A149-A02E3A5296C7"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-06-30T05:59:00+01:00",
+                "primarySource": true,
+                "practitioner": [
+                    {
+                        "role": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/v2/0443",
+                                    "code": "AP",
+                                    "display": "Administering Provider"
+                                }
+                            ]
+                        },
+                        "actor": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "note": [
+                    {
+                        "text": "immunization note"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType":"MedicationRequest",
+                "id":"medicationrequest1",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension":[
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 11
+                            }
+                        ]
+                    }
+                ],
+                "identifier":[
+                    {
+                        "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+                    }
+                ],
+                "status":"active",
+                "intent":"order",
+                "medicationReference":{
+                    "reference":"Medication/20"
+                },
+                "subject":{
+                    "reference":"Patient/2"
+                },
+                "authoredOn":"2017-11-10T00:00:00+00:00",
+                "recorder":{
+                    "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "dosageInstruction":[
+                    {
+                        "text":"1 tablet once a day",
+                        "patientInstruction":"Take in morning"
+                    }
+                ],
+                "dispenseRequest":{
+                    "validityPeriod":{
+                        "start":"2017-11-10T00:00:00+00:00",
+                        "end":"2018-08-15T00:00:00+01:00"
+                    }
+                },
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/medicationrequest2"
+                    }
+                ]
+            }
+
+        },
+        {
+            "resource": {
+                "resourceType":"MedicationRequest",
+                "id":"medicationrequest2",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valueUnsignedInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valueUnsignedInt": 0
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatusReason-1",
+                        "extension": [
+                            {
+                                "url": "statusReason",
+                                "valueCodeableConcept": {
+                                    "text": "Clinical Contra-indication"
+                                }
+                            },
+                            {
+                                "url": "statusChangeDate",
+                                "valueDateTime": "2010-01-18T14:33:16.397+00:00"
+                            }
+                        ]
+                    }
+                ],
+                "identifier":[
+                    {
+                        "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+                    }
+                ],
+                "groupIdentifier":{
+                    "value":"M-3"
+                },
+                "status":"active",
+                "intent":"plan",
+                "medicationReference":{
+                    "reference":"Medication/20"
+                },
+                "subject":{
+                    "reference":"Patient/2"
+                },
+                "authoredOn":"2017-11-10T00:00:00+00:00",
+                "recorder":{
+                    "reference":"Practitioner/1"
+                },
+                "dosageInstruction":[
+                    {
+                        "text":"1 tablet once a day",
+                        "patientInstruction":"Take in morning"
+                    }
+                ],
+                "dispenseRequest":{
+                    "validityPeriod":{
+                        "start":"2017-11-10T00:00:00+00:00",
+                        "end":"2018-08-15T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "value": 100,
+                        "unit": "device"
+                    },
+                    "expectedSupplyDuration":{
+                        "value":28,
+                        "unit":"day",
+                        "system":"http://unitsofmeasure.org",
+                        "code":"d"
+                    },
+                    "performer":{
+                        "reference":"Organization/1"
+                    }
+                },
+                "note": [
+                    {
+                        "text": "Example note text 1"
+                    },
+                    {
+                        "text": "Example note text 2"
+                    },
+                    {
+                        "text": "Example note text 3"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "20",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "430127000",
+                            "display": "Oral Form Oxycodone (product)"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "referralrequest1",
+                "authoredOn": "2010-01-19",
+                "priority": "routine",
+                "description": "Referred for investigation into low blood pressure",
+                "specialty": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/NullFlavor",
+                            "code": "UNK",
+                            "display": "unknown"
+                        }
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+                    },
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ubr-number",
+                        "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ProcedureRequest",
+                "id": "procedurerequestid1",
+                "status": "active",
+                "intent": "plan",
+                "authoredOn": "2010-01-13T15:29:50.1+00:00",
+                "code": {
+                    "text": "test"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "observationcommentid1",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100"
+                        }
+                    ]
+                },
+                "issued": "2010-01-13T15:29:50.3+00:00",
+                "comment": "observation comment"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "observationuncategorisedid1",
+                "code": {
+                    "text": "Test"
+                },
+                "issued": "2010-01-13T15:29:50.3+00:00",
+                "comment": "observation uncategorised"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Flag",
+                "id": "flagid1",
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "F550CC56-EF65-4934-A7B1-3DC2E02243C3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "text": "GP Surgery"
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/v3/ParticipationType",
+                                        "code": "PPRF",
+                                        "display": "primary performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2010-01-13T15:20:00+00:00",
+                    "end": "2010-01-13T16:20:00+00:00"
+                },
+                "location": [
+                    {
+                        "location": {
+                            "reference": "Location/EB3994A6-5A87-4B53-A414-913137072F57"
+                        }
+                    }
+                ],
+                "serviceProvider": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "conditionid1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
+                        "valueReference": {
+                            "reference": "Observation/7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "ReferralRequest/D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "ReferralRequest/82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "DocumentReference/8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "minor"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "onsetDateTime": "2020-09-06",
+                "abatementDateTime": "2020-10-04T00:00:00+01:00",
+                "assertedDate": "2020-09-07T10:12:02.093+01:00",
+                "asserter": {
+                    "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "note": [
+                    {
+                        "text": "Condition note"
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "54321",
+                            "display": "test display",
+                            "extension": [
+                                {
+                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "1234567"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "bloodpressure1",
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "42Q5.00",
+                            "display": "Prothrombin time",
+                            "userSelected": true
+                        },
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "bloodPressureCode1"
+                        }
+                    ]
+                },
+                "comment": "Blood pressure 1"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "bloodpressure3",
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "42Q5.00",
+                            "display": "Prothrombin time",
+                            "userSelected": true
+                        },
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "bloodPressureCode3"
+                        }
+                    ]
+                },
+                "comment": "Blood pressure 3"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "bloodpressure2",
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "42Q5.00",
+                            "display": "Prothrombin time",
+                            "userSelected": true
+                        },
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "bloodPressureCode2"
+                        }
+                    ]
+                },
+                "comment": "Blood pressure 2"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+                "meta": {
+                    "versionId": "4749697187075864793",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "McAvenue",
+                        "given": [
+                            "David"
+                        ],
+                        "prefix": [
+                            "Dr"
+                        ]
+                    }
+                ],
+                "gender": "male"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DiagnosticReport",
+                "id": "96B93E28-293D-46E7-B4C2-D477EEBF7098",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "96B93E28-293D-46E7-B4C2-D477EEBF7098"
+                    }
+                ],
+                "status": "unknown",
+                "category": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v2/0074",
+                            "code": "PAT",
+                            "display": "Pathology (gross & histopath, not surgical)"
+                        }
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "721981007",
+                            "display": "Diagnostic studies report"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "performer": [
+                    {
+                        "actor": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "issued": "2010-02-25T15:41:00+00:00",
+                "specimen": [
+                    {
+                        "reference": "Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+                    },
+                    {
+                        "reference": "Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1"
+                    },
+                    {
+                        "reference": "Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2"
+                    }
+                ],
+                "result": [
+                    {
+                        "reference": "Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2"
+                    },
+                    {
+                        "reference": "Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"
+                    },
+                    {
+                        "reference": "Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+                    },
+                    {
+                        "reference": "Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"
+                    },
+                    {
+                        "reference": "Observation/D0A358C9-4833-4827-B14B-E8515C25CB12"
+                    },
+                    {
+                        "reference": "Observation/D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Specimen",
+                "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+                    }
+                ],
+                "accessionIdentifier":{
+                    "value":"CH000056DN"
+                },
+                "type":{
+                    "text":"URINE"
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "receivedTime":"2010-02-24T15:41:00+00:00",
+                "collection":{
+                    "collectedDateTime":"2010-02-23T00:00:00+00:00"
+                }
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Specimen",
+                "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1"
+                    }
+                ],
+                "accessionIdentifier":{
+                    "value":"CH000056DO"
+                },
+                "type":{
+                    "text":"SERUM"
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "receivedTime":"2001-03-30T12:21:00+01:00",
+                "collection":{
+                    "collectedDateTime":"2010-02-23T15:41:00+00:00"
+                }
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Specimen",
+                "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2"
+                    }
+                ],
+                "accessionIdentifier":{
+                    "value":"CH000056DP"
+                },
+                "type":{
+                    "text":"SERUM"
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "receivedTime":"2010-02-24T15:41:00+00:00"
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2"
+                    }
+                ],
+                "status":"unknown",
+                "category":[
+                    {
+                        "coding":[
+                            {
+                                "system":"http://hl7.org/fhir/observation-category",
+                                "code":"laboratory",
+                                "display":"Laboratory"
+                            }
+                        ]
+                    }
+                ],
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://read.info/readv2",
+                            "code":"465..00",
+                            "display":"Urine pregnancy test",
+                            "userSelected":true
+                        },
+                        {
+                            "extension":[
+                                {
+                                    "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension":[
+                                        {
+                                            "url":"descriptionId",
+                                            "valueId":"2564081000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system":"http://snomed.info/sct",
+                            "code":"1003161000000106",
+                            "display":"Urine pregnancy test"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2010-02-23",
+                "issued":"2010-02-25T15:41:00+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"NEGATIVE\n     In normal pregnancies the test will usually be positive from the\n     second day after the expected menstruation.",
+                "specimen":{
+                    "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+                },
+                "related":[
+                    {
+                        "type":"has-member",
+                        "target":{
+                            "reference":"Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2-COMM"
+                    }
+                ],
+                "status":"unknown",
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://snomed.info/sct",
+                            "code":"37331000000100",
+                            "display":"Comment note"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2020-12-15T15:17:04.917+00:00",
+                "issued":"2020-12-15T15:17:04.917+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"(q) - Normal - No Action",
+                "related":[
+                    {
+                        "type":"derived-from",
+                        "target":{
+                            "reference":"Observation/B7F05EA7-A1A4-48C0-9C4C-CDB5768796B2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+                    }
+                ],
+                "status":"unknown",
+                "category":[
+                    {
+                        "coding":[
+                            {
+                                "system":"http://hl7.org/fhir/observation-category",
+                                "code":"laboratory",
+                                "display":"Laboratory"
+                            }
+                        ]
+                    }
+                ],
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://read.info/readv2",
+                            "code":"4465.00",
+                            "display":"Serum oestradiol level",
+                            "userSelected":true
+                        },
+                        {
+                            "extension":[
+                                {
+                                    "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension":[
+                                        {
+                                            "url":"descriptionId",
+                                            "valueId":"2551971000000110"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system":"http://snomed.info/sct",
+                            "code":"1010521000000102",
+                            "display":"Serum oestradiol level"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2010-02-23",
+                "issued":"2010-02-25T15:41:00+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "valueQuantity":{
+                    "value":8.800,
+                    "unit":"mmol/L"
+                },
+                "specimen":{
+                    "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-1"
+                },
+                "referenceRange":[
+                    {
+                        "low":{
+                            "value":10.000,
+                            "unit":"mmol/L"
+                        },
+                        "high":{
+                            "value":90.000,
+                            "unit":"mmol/L"
+                        }
+                    }
+                ],
+                "related":[
+                    {
+                        "type":"has-member",
+                        "target":{
+                            "reference":"Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"
+                    }
+                ],
+                "status":"unknown",
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://snomed.info/sct",
+                            "code":"37331000000100",
+                            "display":"Comment note"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2020-12-15T15:17:13.46+00:00",
+                "issued":"2020-12-15T15:17:13.46+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"(q) - Normal - No Action",
+                "related":[
+                    {
+                        "type":"derived-from",
+                        "target":{
+                            "reference":"Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"D0A358C9-4833-4827-B14B-E8515C25CB12",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"D0A358C9-4833-4827-B14B-E8515C25CB12"
+                    }
+                ],
+                "status":"unknown",
+                "category":[
+                    {
+                        "coding":[
+                            {
+                                "system":"http://hl7.org/fhir/observation-category",
+                                "code":"laboratory",
+                                "display":"Laboratory"
+                            }
+                        ]
+                    }
+                ],
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://read.info/readv2",
+                            "code":"4483.00",
+                            "display":"Serum ACTH",
+                            "userSelected":true
+                        },
+                        {
+                            "extension":[
+                                {
+                                    "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension":[
+                                        {
+                                            "url":"descriptionId",
+                                            "valueId":"2563401000000119"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system":"http://snomed.info/sct",
+                            "code":"997201000000100",
+                            "display":"Serum ACTH (adrenocorticotrophic hormone) level"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2010-02-23",
+                "issued":"2010-02-25T15:41:00+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"Test not available",
+                "specimen":{
+                    "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-2"
+                },
+                "related":[
+                    {
+                        "type":"has-member",
+                        "target":{
+                            "reference":"Observation/D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource":{
+                "resourceType":"Observation",
+                "id":"D0A358C9-4833-4827-B14B-E8515C25CB12-COMM",
+                "meta":{
+                    "profile":[
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier":[
+                    {
+                        "system":"https://EMISWeb/A82038",
+                        "value":"D0A358C9-4833-4827-B14B-E8515C25CB12-COMM"
+                    }
+                ],
+                "status":"unknown",
+                "code":{
+                    "coding":[
+                        {
+                            "system":"http://snomed.info/sct",
+                            "code":"37331000000100",
+                            "display":"Comment note"
+                        }
+                    ]
+                },
+                "subject":{
+                    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+                },
+                "effectiveDateTime":"2020-12-15T15:17:13.51+00:00",
+                "issued":"2020-12-15T15:17:13.51+00:00",
+                "performer":[
+                    {
+                        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "comment":"(q) - Normal - No Action",
+                "related":[
+                    {
+                        "type":"derived-from",
+                        "target":{
+                            "reference":"Observation/D0A358C9-4833-4827-B14B-E8515C25CB12"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+                "meta": {
+                    "versionId": "1112974926854455048",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-OrganisationType-1",
+                                "code": "gp-practice"
+                            }
+                        ],
+                        "text": "GP Practice"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-13-topic-without-date.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-13-topic-without-date.json
@@ -1,0 +1,228 @@
+{
+    "resourceType": "Bundle",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "List",
+                "title": "GP Surgery",
+                "id": "consultationid1",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "325851000000107",
+                            "display": "Consultation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-01-13T15:29:50.283+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/topicid1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "topicid1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "title": "Endometriosis of uterus",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/category1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "category1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "ProcedureRequest/procedurerequestid1"
+                        }
+                    }
+                ]
+            }
+        },
+
+        {
+            "resource": {
+                "resourceType": "ProcedureRequest",
+                "id": "procedurerequestid1",
+                "status": "active",
+                "intent": "plan",
+                "authoredOn": "2010-01-13T15:29:50.1+00:00",
+                "code": {
+                    "text": "test"
+                }
+            }
+        },
+
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "F550CC56-EF65-4934-A7B1-3DC2E02243C3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "text": "GP Surgery"
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/v3/ParticipationType",
+                                        "code": "PPRF",
+                                        "display": "primary performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2010-01-13T15:20:00+00:00",
+                    "end": "2010-01-13T16:20:00+00:00"
+                },
+                "location": [
+                    {
+                        "location": {
+                            "reference": "Location/EB3994A6-5A87-4B53-A414-913137072F57"
+                        }
+                    }
+                ],
+                "serviceProvider": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                }
+            }
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-14-category-codes.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-14-category-codes.json
@@ -81,23 +81,15 @@
                         }
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/conditionid1"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "entry": [
                     {
                         "item": {
                             "reference": "List/category1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/category2"
                         }
                     }
                 ]
@@ -239,75 +231,129 @@
         },
         {
             "resource": {
-                "resourceType": "Condition",
-                "id": "conditionid1",
+                "resourceType": "List",
+                "id": "category2",
                 "meta": {
                     "profile": [
-                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
-                        "valueReference": {
-                            "reference": "Observation/7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "ReferralRequest/D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "ReferralRequest/82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "DocumentReference/8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
-                        "valueCode": "minor"
-                    }
-                ],
-                "clinicalStatus": "active",
-                "onsetDateTime": "2020-09-06",
-                "abatementDateTime": "2020-10-04T00:00:00+01:00",
-                "assertedDate": "2020-09-07T10:12:02.093+01:00",
-                "asserter": {
-                    "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
-                },
-                "note": [
-                    {
-                        "text": "Condition note"
-                    }
-                ],
+                "status": "current",
+                "mode": "snapshot",
                 "code": {
                     "coding": [
                         {
                             "system": "http://snomed.info/sct",
-                            "code": "54321",
-                            "display": "test display",
-                            "extension": [
-                                {
-                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
-                                    "extension": [
-                                        {
-                                            "url": "descriptionId",
-                                            "valueId": "1234567"
-                                        }
-                                    ]
-                                }
-                            ]
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
                         }
                     ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "DocumentReference/documentreference1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "documentreference1",
+                "meta": {
+                    "versionId": "5774557612980378259",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25611000000107",
+                            "display": "Referral letter",
+                            "userSelected": true
+                        }
+                    ],
+                    "text": "Referral Letter (21-Sep-2020)"
+                },
+                "created": "2020-09-21",
+                "indexed": "2020-09-21T14:17:59.607+01:00",
+                "custodian": {
+                    "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "text/richtext",
+                            "title": "some title"
+                        }
+                    }
+                ],
+                "description": "for 2 week rule referral - skin",
+                "author": [
+                    {
+                        "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "context": {
+                    "practiceSetting": {
+                        "coding": [
+                            {
+                                "display": "Practice Setting Display"
+                            }
+                        ],
+                        "text": "Practice Setting Text"
+                    }
                 }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+                "meta": {
+                    "versionId": "1112974926854455048",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-OrganisationType-1",
+                                "code": "gp-practice"
+                            }
+                        ],
+                        "text": "GP Practice"
+                    }
+                ]
             }
         }
     ]

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-15-related-problem-no-title.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-15-related-problem-no-title.json
@@ -56,7 +56,6 @@
                     ]
                 },
                 "status": "current",
-                "title": "Endometriosis of uterus",
                 "code": {
                     "coding": [
                         {

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-16-topic-codes.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-16-topic-codes.json
@@ -42,6 +42,11 @@
                         "item": {
                             "reference": "List/topicid1"
                         }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/topicid2"
+                        }
                     }
                 ]
             }
@@ -56,7 +61,6 @@
                     ]
                 },
                 "status": "current",
-                "title": "Endometriosis of uterus",
                 "code": {
                     "coding": [
                         {
@@ -81,23 +85,53 @@
                         }
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/conditionid1"
-                                }
-                            }
-                        ]
-                    }
-                ],
                 "entry": [
                     {
                         "item": {
                             "reference": "List/category1"
+                        }
+                    }
+                ]
+            }
+        },{
+            "resource": {
+                "resourceType": "List",
+                "id": "topicid2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "title": "Test Title",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/category2"
                         }
                     }
                 ]
@@ -239,75 +273,130 @@
         },
         {
             "resource": {
-                "resourceType": "Condition",
-                "id": "conditionid1",
+                "resourceType": "List",
+                "id": "category2",
                 "meta": {
                     "profile": [
-                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
-                        "valueReference": {
-                            "reference": "Observation/7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "ReferralRequest/D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "ReferralRequest/82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "DocumentReference/8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
-                        "valueCode": "minor"
-                    }
-                ],
-                "clinicalStatus": "active",
-                "onsetDateTime": "2020-09-06",
-                "abatementDateTime": "2020-10-04T00:00:00+01:00",
-                "assertedDate": "2020-09-07T10:12:02.093+01:00",
-                "asserter": {
-                    "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
-                },
-                "note": [
-                    {
-                        "text": "Condition note"
-                    }
-                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
                 "code": {
                     "coding": [
                         {
                             "system": "http://snomed.info/sct",
-                            "code": "54321",
-                            "display": "test display",
-                            "extension": [
-                                {
-                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
-                                    "extension": [
-                                        {
-                                            "url": "descriptionId",
-                                            "valueId": "1234567"
-                                        }
-                                    ]
-                                }
-                            ]
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
                         }
                     ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "encounter": {
+                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+                },
+                "date": "2010-07-14T16:32:32.03+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "DocumentReference/documentreference1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "documentreference1",
+                "meta": {
+                    "versionId": "5774557612980378259",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "25611000000107",
+                            "display": "Referral letter",
+                            "userSelected": true
+                        }
+                    ],
+                    "text": "Referral Letter (21-Sep-2020)"
+                },
+                "created": "2020-09-21",
+                "indexed": "2020-09-21T14:17:59.607+01:00",
+                "custodian": {
+                    "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                },
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "text/richtext",
+                            "title": "some title"
+                        }
+                    }
+                ],
+                "description": "for 2 week rule referral - skin",
+                "author": [
+                    {
+                        "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "context": {
+                    "practiceSetting": {
+                        "coding": [
+                            {
+                                "display": "Practice Setting Display"
+                            }
+                        ],
+                        "text": "Practice Setting Text"
+                    }
                 }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73",
+                "meta": {
+                    "versionId": "1112974926854455048",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-OrganisationType-1",
+                                "code": "gp-practice"
+                            }
+                        ],
+                        "text": "GP Practice"
+                    }
+                ]
             }
         }
     ]

--- a/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-17-topic-no-categories.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/input-bundle-17-topic-no-categories.json
@@ -81,65 +81,6 @@
                         }
                     ]
                 },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
-                        "extension": [
-                            {
-                                "url": "target",
-                                "valueReference": {
-                                    "reference": "Condition/conditionid1"
-                                }
-                            }
-                        ]
-                    }
-                ],
-                "entry": [
-                    {
-                        "item": {
-                            "reference": "List/category1"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "resource": {
-                "resourceType": "List",
-                "id": "category1",
-                "meta": {
-                    "profile": [
-                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
-                    ]
-                },
-                "status": "current",
-                "mode": "snapshot",
-                "title": "History",
-                "code": {
-                    "coding": [
-                        {
-                            "system": "http://snomed.info/sct",
-                            "code": "24781000000107",
-                            "display": "Category (EHR)"
-                        }
-                    ]
-                },
-                "subject": {
-                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
-                },
-                "encounter": {
-                    "reference": "Encounter/F550CC56-EF65-4934-A7B1-3DC2E02243C3"
-                },
-                "date": "2010-07-14T16:32:32.03+01:00",
-                "orderedBy": {
-                    "coding": [
-                        {
-                            "system": "http://hl7.org/fhir/list-order",
-                            "code": "system",
-                            "display": "Sorted by System"
-                        }
-                    ]
-                },
                 "entry": [
                     {
                         "item": {
@@ -149,7 +90,6 @@
                 ]
             }
         },
-
         {
             "resource": {
                 "resourceType": "ProcedureRequest",
@@ -162,7 +102,6 @@
                 }
             }
         },
-
         {
             "resource": {
                 "resourceType": "Encounter",
@@ -234,79 +173,6 @@
                 ],
                 "serviceProvider": {
                     "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
-                }
-            }
-        },
-        {
-            "resource": {
-                "resourceType": "Condition",
-                "id": "conditionid1",
-                "meta": {
-                    "profile": [
-                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
-                    ]
-                },
-                "extension": [
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
-                        "valueReference": {
-                            "reference": "Observation/7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "ReferralRequest/D2EA00FC-7B85-46C5-A0B7-E49C53C054D0"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "ReferralRequest/82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
-                        "valueReference": {
-                            "reference": "DocumentReference/8747DFC5-11B7-4A77-B2F3-7720CC58C2FC"
-                        }
-                    },
-                    {
-                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
-                        "valueCode": "minor"
-                    }
-                ],
-                "clinicalStatus": "active",
-                "onsetDateTime": "2020-09-06",
-                "abatementDateTime": "2020-10-04T00:00:00+01:00",
-                "assertedDate": "2020-09-07T10:12:02.093+01:00",
-                "asserter": {
-                    "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
-                },
-                "note": [
-                    {
-                        "text": "Condition note"
-                    }
-                ],
-                "code": {
-                    "coding": [
-                        {
-                            "system": "http://snomed.info/sct",
-                            "code": "54321",
-                            "display": "test display",
-                            "extension": [
-                                {
-                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
-                                    "extension": [
-                                        {
-                                            "url": "descriptionId",
-                                            "valueId": "1234567"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
                 }
             }
         }

--- a/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-ehr-extract-response-from-json.xml
@@ -212,6 +212,24 @@
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
+        <component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100714180700"/><high value="20130713162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100714163232"/>
+        <component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20100714180700"/><high value="20130713162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100714163232"/>
         <component typeCode="COMP" >
     <ObservationStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3" />
@@ -236,6 +254,10 @@
     </agentRef>
 </Participant>
     </ObservationStatement>
+</component>
+    </CompoundStatement>
+</component>
+    </CompoundStatement>
 </component>
     </ehrComposition>
 </component>
@@ -269,6 +291,24 @@
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
+        <component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100113152000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152950"/>
+        <component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100113152000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152950"/>
         <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3" />
@@ -293,6 +333,10 @@ The line below contains special characters...
     </agentRef>
 </Participant>
     </NarrativeStatement>
+</component>
+    </CompoundStatement>
+</component>
+    </CompoundStatement>
 </component>
     </ehrComposition>
 </component>
@@ -326,6 +370,24 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
+        <component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100123134800"/>
+        </effectiveTime>
+        <availabilityTime value="20100123140354"/>
+        <component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100123134800"/>
+        </effectiveTime>
+        <availabilityTime value="20100123140354"/>
         <component typeCode="COMP" >
     <ObservationStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3" />
@@ -410,7 +472,18 @@ The line below contains special characters...
     </agentRef>
 </Participant>
     </ObservationStatement>
-</component><component typeCode="COMP" >
+</component>
+    </CompoundStatement>
+</component><component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100123134800"/>
+        </effectiveTime>
+        <availabilityTime value="20100123140354"/>
+        <component typeCode="COMP" >
     <ObservationStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3" />
         <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
@@ -459,6 +532,10 @@ The line below contains special characters...
 </Participant>
     </ObservationStatement>
 </component>
+    </CompoundStatement>
+</component>
+    </CompoundStatement>
+</component>
     </ehrComposition>
 </component>
                 <component typeCode="COMP">
@@ -491,6 +568,24 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
+        <component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100609"/>
+        </effectiveTime>
+        <availabilityTime value="20100609175121"/>
+        <component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100609"/>
+        </effectiveTime>
+        <availabilityTime value="20100609175121"/>
         <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3" />
@@ -503,6 +598,10 @@ The line below contains special characters...
     </agentRef>
 </Participant>
     </NarrativeStatement>
+</component>
+    </CompoundStatement>
+</component>
+    </CompoundStatement>
 </component>
     </ehrComposition>
 </component>
@@ -536,6 +635,24 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
+        <component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100610082200"/>
+        </effectiveTime>
+        <availabilityTime value="20100610081925"/>
+        <component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100610082200"/>
+        </effectiveTime>
+        <availabilityTime value="20100610081925"/>
         <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3" />
@@ -548,6 +665,10 @@ The line below contains special characters...
     </agentRef>
 </Participant>
     </NarrativeStatement>
+</component>
+    </CompoundStatement>
+</component>
+    </CompoundStatement>
 </component>
     </ehrComposition>
 </component>
@@ -581,6 +702,24 @@ The line below contains special characters...
                 <id root="test-id-3"/>
             </agentRef>
         </Participant2>
+        <component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100714175500"/>
+        </effectiveTime>
+        <availabilityTime value="20100714162813"/>
+        <component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+        <id root="test-id-3"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20100714175500"/>
+        </effectiveTime>
+        <availabilityTime value="20100714162813"/>
         <component typeCode="COMP">
     <CompoundStatement classCode="BATTERY" moodCode="EVN">
         <id root="test-id-3"/>
@@ -627,6 +766,10 @@ The line below contains special characters...
         <id root="test-id-3"/>
     </agentRef>
 </Participant>
+    </CompoundStatement>
+</component>
+    </CompoundStatement>
+</component>
     </CompoundStatement>
 </component>
     </ehrComposition>


### PR DESCRIPTION
**Problem**

Topic (areas of discussion within a Consultation) do not appear to be included in the extract message produced by the GP2GP adaptor.

**Work undertaken**

- Mapped GP Connect Topics to GP2GP Compound statements with  `classCode=TOPIC`
- Mapped GP Connect Categories (Headers) to GP2GP Compound statements with `classCode=CATEGORY`
- If a topic has a related problem the snomed code of the problem (if present) is used to code the topic. Otherwise, the snomed code for Unspecified Problem is used. In both cases, the topic's title (if present) is placed in the `originalText` element.