### PR TITLE
NIAD-2580 - Run1 Cycle1 - Body Site value under Procedure is not displayed 

### DIFF
--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseBodySite.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseBodySite.json
@@ -1,0 +1,1002 @@
+{
+    "resourceType": "Bundle",
+    "id": "6a92c467-ff0c-4089-a5d1-285d20cb9f92",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "c168d7d0-9afd-11ed-9c6b-0a58a9feac02",
+                "meta": {
+                    "versionId": "4f79950eab756ab1df01ccc52ba47d76",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+                        "extension": [
+                            {
+                                "url": "registrationPeriod",
+                                "valuePeriod": {
+                                    "start": "2023-01-23",
+                                    "end": "2023-04-23"
+                                }
+                            },
+                            {
+                                "url": "registrationType",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                                            "code": "T",
+                                            "display": "Temporary"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                                            "code": "01",
+                                            "display": "Number present and verified"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "1239577290"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Yell",
+                        "prefix": [
+                            "Mrs"
+                        ],
+                        "given": [
+                            "Louisa"
+                        ]
+                    }
+                ],
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "+441454121205",
+                        "use": "home"
+                    },
+                    {
+                        "system": "phone",
+                        "value": "+447777121205",
+                        "use": "mobile"
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1950-06-09",
+                "address": [
+                    {
+                        "use": "home",
+                        "line": [
+                            "16 Bond Sreet",
+                            "High Moor"
+                        ],
+                        "city": "Leeds",
+                        "district": "West Yorkshire",
+                        "postalCode": "LS26 1AF",
+                        "country": "GBR"
+                    }
+                ],
+                "managingOrganization": {
+                    "reference": "Organization/B84012"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "B84012",
+                "meta": {
+                    "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                        "value": "B2617"
+                    }
+                ],
+                "active": true,
+                "name": "Spring Hall Group Practice",
+                "address": [
+                    {
+                        "use": "work",
+                        "line": [
+                            "101 Yvonne Falls"
+                        ],
+                        "city": "West Carey",
+                        "district": "Norfolk",
+                        "postalCode": "MK3 7SA",
+                        "country": "GBR"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "+441273749184",
+                        "use": "work"
+                    },
+                    {
+                        "system": "fax",
+                        "value": "+441455338473",
+                        "use": "work"
+                    },
+                    {
+                        "system": "email",
+                        "value": "bakers.hill@medicus.health",
+                        "use": "work"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "e83202f6-9afd-11ed-b952-0a58a9feac02",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/df265dd8-9afd-11ed-9add-0a58a9feac02"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "e83202f6-9afd-11ed-b952-0a58a9feac02"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "297217002",
+                            "display": "Rib pain",
+                            "extension": [
+                                {
+                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "437698016"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "assertedDate": "2023-01-23T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/31a0239e-59fb-11ed-946f-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "hurts a lot"
+                    },
+                    {
+                        "text": "Episode: First"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "31a0239e-59fb-11ed-946f-0a58a9feac02",
+                "meta": {
+                    "versionId": "ddf84e3f5b69535fd7d1fd0d51b95300",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "text": "Andrew Guiseley"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "df265dd8-9afd-11ed-9add-0a58a9feac02",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "df265dd8-9afd-11ed-9add-0a58a9feac02"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "446063006",
+                            "display": "MRI of rib",
+                            "extension": [
+                                {
+                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "3027809017"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "effectiveDateTime": "2023-01-23",
+                "issued": "2023-01-23T00:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/31a0239e-59fb-11ed-946f-0a58a9feac02"
+                    },
+                    {
+                        "reference": "Organization/B84012"
+                    }
+                ],
+                "comment": "test additional information",
+                "bodySite": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "60413009",
+                            "display": "Thoracic cage structure",
+                            "extension": [
+                                {
+                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "100385018"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Rib cage"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Problems",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Problems",
+                            "system": "http://snomed.info/sct",
+                            "code": "717711000000103"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Condition/e83202f6-9afd-11ed-b952-0a58a9feac02"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Allergies and adverse reactions",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Allergies and adverse reactions",
+                            "system": "http://snomed.info/sct",
+                            "code": "886921000000105"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Ended allergies",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Ended allergies",
+                            "system": "http://snomed.info/sct",
+                            "code": "1103671000000101"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "ms-04e9d7de-9afe-11ed-ae10-0a58a9feac02",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "ms-04e9d7de-9afe-11ed-ae10-0a58a9feac02"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2023-01-23"
+                    }
+                ],
+                "status": "completed",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-04e9d7de-9afe-11ed-ae10-0a58a9feac02"
+                    }
+                ],
+                "medicationReference": {
+                    "reference": "Medication/4555611000001104"
+                },
+                "effectivePeriod": {
+                    "start": "2023-01-23",
+                    "end": "2023-02-05"
+                },
+                "dateAsserted": "2023-01-23",
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "take 2 spoons twice a day"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "4555611000001104",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "4555611000001104",
+                            "display": "Malarivon 80mg/5ml syrup (Wallace Manufacturing Chemists Ltd)",
+                            "extension": [
+                                {
+                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "41476601000001114"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "mr-04e9d7de-9afe-11ed-ae10-0a58a9feac02",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "mr-04e9d7de-9afe-11ed-ae10-0a58a9feac02"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/4555611000001104"
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "authoredOn": "2023-01-23",
+                "recorder": {
+                    "reference": "Practitioner/31a0239e-59fb-11ed-946f-0a58a9feac02"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Practitioner/5204ba5a-59fb-11ed-9039-0a58a9feac02"
+                    }
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "take 2 spoons twice a day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2023-01-23",
+                        "end": "2023-02-05"
+                    },
+                    "quantity": {
+                        "value": 75,
+                        "unit": "ml"
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 14,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d",
+                        "unit": "day"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "04ea2572-9afe-11ed-b369-0a58a9feac02",
+                "identifier": [
+                    {
+                        "system": "https://medicus.health",
+                        "value": "04ea2572-9afe-11ed-b369-0a58a9feac02"
+                    }
+                ],
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "status": "completed",
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/mr-04e9d7de-9afe-11ed-ae10-0a58a9feac02"
+                    }
+                ],
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/4555611000001104"
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "authoredOn": "2023-01-23",
+                "recorder": {
+                    "reference": "Practitioner/31a0239e-59fb-11ed-946f-0a58a9feac02"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Practitioner/5204ba5a-59fb-11ed-9039-0a58a9feac02"
+                    }
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "take 2 spoons twice a day"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2023-01-23",
+                        "end": "2023-02-05"
+                    },
+                    "quantity": {
+                        "value": 75,
+                        "unit": "ml"
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 14,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d",
+                        "unit": "day"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "5204ba5a-59fb-11ed-9039-0a58a9feac02",
+                "meta": {
+                    "versionId": "90cdc1c77d9e23d07db92c4758404db4",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "text": "Neill Jones"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "72d5edc8e13bdd913b86a0d0415d8253",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1"
+                    ]
+                },
+                "practitioner": {
+                    "reference": "Practitioner/5204ba5a-59fb-11ed-9039-0a58a9feac02"
+                },
+                "organization": {
+                    "reference": "Organization/B84012"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "List of consultations",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "List of consultations",
+                            "system": "http://snomed.info/sct",
+                            "code": "1149501000000101"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Immunisations",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Immunisations",
+                            "system": "http://snomed.info/sct",
+                            "code": "1102181000000102"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Uncategorised data",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Miscellaneous records",
+                            "system": "http://snomed.info/sct",
+                            "code": "826501000000100"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/df265dd8-9afd-11ed-9add-0a58a9feac02"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Investigations and results",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Investigations and results",
+                            "system": "http://snomed.info/sct",
+                            "code": "887191000000108"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Outbound referral",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Outbound referral",
+                            "system": "http://snomed.info/sct",
+                            "code": "792931000000107"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Patient recall administration",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Patient recall administration",
+                            "system": "http://snomed.info/sct",
+                            "code": "714311000000108"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "note": [
+                    {
+                        "text": "Information not available."
+                    }
+                ],
+                "emptyReason": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+                            "code": "no-content-recorded",
+                            "display": "No Content Recorded"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Medications and medical devices",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Medications and medical devices",
+                            "system": "http://snomed.info/sct",
+                            "code": "933361000000108"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/ms-04e9d7de-9afe-11ed-ae10-0a58a9feac02"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Problems - uncategorised data related to problems",
+                "code": {
+                    "coding": [
+                        {
+                            "display": "Problems - uncategorised data related to problems",
+                            "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/GPConnect-SecondaryListValues-1",
+                            "code": "problems-uncategorised-data-related-to-problems"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/df265dd8-9afd-11ed-9add-0a58a9feac02"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/docker/wiremock/stubs/mappings/retrievePatientStructuredRecordBodySite.json
+++ b/docker/wiremock/stubs/mappings/retrievePatientStructuredRecordBodySite.json
@@ -1,0 +1,27 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "urlPattern": "/.*/STU3/1/gpconnect/fhir/Patient/[$]gpc[.]migratestructuredrecord",
+    "bodyPatterns" : [ {
+      "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
+    },
+    {
+      "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '1239577290')]"
+    }]
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "correctPatientStructuredRecordResponseBodySite.json",
+    "headers": {
+      "Server": "nginx",
+      "Date": "{{now format='E, d MMM y HH:mm:ss z'}}",
+      "Content-Type": "application/fhir+json;charset=UTF-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-store",
+      "X-Powered-By": "HAPI FHIR 3.0.0 REST Server (FHIR Server; FHIR 3.0.1/DSTU3)",
+      "Strict-Transport-Security":"max-age=31536000"
+    }
+  }
+}

--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -71,6 +71,7 @@ public class EhrExtractTest {
     private static final String NHS_NUMBER_RESPONSE_MISSING_PATIENT_RESOURCE = "2906543841";
     private static final String NHS_NUMBER_MEDICUS_BASED_ON = "9302014592";
     private static final String NHS_NUMBER_INVALID_CONTENT_TYPE_DOC = "9817280691";
+    private static final String NHS_NUMBER_BODY_SITE = "1239577290";
     private static final String EHR_EXTRACT_REQUEST_TEST_FILE = "/ehrExtractRequest.json";
     private static final String EHR_EXTRACT_REQUEST_WITHOUT_NHS_NUMBER_TEST_FILE = "/ehrExtractRequestWithoutNhsNumber.json";
     private static final String EHR_EXTRACT_REQUEST_NO_DOCUMENTS = "/ehrExtractRequestWithNoDocuments.json";
@@ -107,6 +108,7 @@ public class EhrExtractTest {
 
     private static final CharSequence XML_NAMESPACE = "/urn:hl7-org:v3:";
     private static final String DOCUMENT_REFERENCE_XPATH_TEMPLATE = "/RCMR_IN030000UK06/ControlActEvent/subject/EhrExtract/component/ehrFolder/component/ehrComposition/component/NarrativeStatement/reference/referredToExternalDocument/text/reference[@value='cid:%s']";
+    private static final String BODY_SITE_REFERENCE_XPATH_TEMPLATE = "/RCMR_IN030000UK06/ControlActEvent/subject/EhrExtract/component/ehrFolder/component/ehrComposition/component/ObservationStatement/pertinentInformation/pertinentAnnotation/text[contains(text(), 'BodySite: Rib cage')]";
 
     private final MhsMockRequestsJournal mhsMockRequestsJournal =
         new MhsMockRequestsJournal(getEnvVar("GP2GP_MHS_MOCK_BASE_URL", "http://localhost:8081"));
@@ -337,6 +339,39 @@ public class EhrExtractTest {
             .format(DOCUMENT_REFERENCE_XPATH_TEMPLATE, documentId)
             .replace("/", XML_NAMESPACE);
         XmlAssert.assertThat(ehrExtractMhsRequest.getPayload()).hasXPath(documentReferenceXPath);
+    }
+
+
+    @Test
+    public void When_ExtractRequest_ContainsObservationWithBodySite_ExpectBodySiteValueInPertinentInformationText() throws Exception {
+        String conversationId = UUID.randomUUID().toString();
+        String ehrExtractRequest = buildEhrExtractRequest(conversationId, NHS_NUMBER_BODY_SITE, FROM_ODS_CODE_2);
+        MessageQueue.sendToMhsInboundQueue(ehrExtractRequest);
+
+        var ehrExtractStatus = waitFor(() -> getFinishedEhrExtractStatus(conversationId));
+        assertThatInitialRecordWasCreated(conversationId, ehrExtractStatus, NHS_NUMBER_BODY_SITE, FROM_ODS_CODE_2);
+        var gpcAccessStructured = ehrExtractStatus.get(GPC_ACCESS_STRUCTURED, Document.class);
+        assertThatAccessStructuredWasFetched(conversationId, gpcAccessStructured);
+
+        var ehrExtractCore = ehrExtractStatus.get(EHR_EXTRACT_CORE, Document.class);
+        assertThatExtractCoreMessageWasSent(ehrExtractCore);
+
+        var ehrContinue = ehrExtractStatus.get(EHR_CONTINUE, Document.class);
+        assertThatExtractContinueMessageWasSent(ehrContinue);
+
+        var ackPending = ehrExtractStatus.get(ACK_TO_PENDING, Document.class);
+        assertThatAcknowledgementPending(ackPending, ACCEPTED_ACKNOWLEDGEMENT_TYPE_CODE);
+
+        var requestJournals = waitFor(() -> {
+            try {
+                return mhsMockRequestsJournal.getRequestsJournal(conversationId);
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        XmlAssert.assertThat(requestJournals.get(0).getPayload())
+                .hasXPath(BODY_SITE_REFERENCE_XPATH_TEMPLATE.replace("/", XML_NAMESPACE));
     }
 
     private Document getFinishedEhrExtractStatus(String conversationId) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapper.java
@@ -29,6 +29,8 @@ import uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils;
 import uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils;
 import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
 
+import static uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils.extractTextOrCoding;
+
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Component
 @Slf4j
@@ -67,6 +69,11 @@ public class ObservationStatementMapper {
                     structuredObservationValueMapper.mapObservationValueToStructuredElement(value));
             }
         }
+
+        var bodySite = extractTextOrCoding(observation.getBodySite())
+                .map(text -> String.format("BodySite: %s", text));
+
+        bodySite.ifPresent(observationStatementTemplateParametersBuilder::comment);
 
         if (observation.hasReferenceRange() && observation.hasValueQuantity()) {
             observationStatementTemplateParametersBuilder.referenceRange(
@@ -159,8 +166,13 @@ public class ObservationStatementMapper {
         }
 
         if (observation.hasComment()) {
-            commentBuilder.append(observation.getComment());
+            commentBuilder.append(observation.getComment()).append(StringUtils.SPACE);
         }
+
+        var bodySite = extractTextOrCoding(observation.getBodySite())
+                .map(text -> String.format("BodySite: %s", text));
+
+        bodySite.ifPresent(commentBuilder::append);
 
         buildActualProblemTextIfExists(observation)
             .map(t -> StringUtils.SPACE + t)

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapperTest.java
@@ -117,7 +117,8 @@ public class ObservationStatementMapperTest {
         + "example-observation-resource-43.json";
     private static final String INPUT_JSON_WITH_EFFECTIVE_PERIOD_NO_END = TEST_FILE_DIRECTORY
         + "example-observation-resource-44.json";
-
+    private static final String INPUT_JSON_WITH_BODY_SITE = TEST_FILE_DIRECTORY
+        + "example-observation-with-body-site.json";
     private static final String OUTPUT_XML_USES_EFFECTIVE_DATE_TIME = TEST_FILE_DIRECTORY
         + "expected-output-observation-statement-1.xml";
     private static final String OUTPUT_XML_USES_UNK_DATE_TIME = TEST_FILE_DIRECTORY
@@ -180,6 +181,8 @@ public class ObservationStatementMapperTest {
         + "expected-output-observation-statement-31.xml";
     private static final String OUTPUT_XML_WITH_EFFECTIVE_TIME_NO_END = TEST_FILE_DIRECTORY
         + "expected-output-observation-statement-32.xml";
+    private static final String OUTPUT_XML_WITH_BODY_SITE = TEST_FILE_DIRECTORY
+            + "expected-output-observation-with-body-site.xml";
 
     private CharSequence expectedOutputMessage;
     private ObservationStatementMapper observationStatementMapper;
@@ -306,7 +309,8 @@ public class ObservationStatementMapperTest {
                 OUTPUT_XML_WITH_REFERENCE_RANGE_NO_LOW_NO_VALUE_QUANTITY),
             Arguments.of(INPUT_JSON_WITH_REFERENCE_RANGE_NO_HIGH_NO_VALUE_QUANTITY,
                 OUTPUT_XML_WITH_REFERENCE_RANGE_NO_HIGH_NO_VALUE_QUANTITY),
-            Arguments.of(INPUT_JSON_WITH_EFFECTIVE_PERIOD_NO_END, OUTPUT_XML_WITH_EFFECTIVE_TIME_NO_END)
+            Arguments.of(INPUT_JSON_WITH_EFFECTIVE_PERIOD_NO_END, OUTPUT_XML_WITH_EFFECTIVE_TIME_NO_END),
+            Arguments.of(INPUT_JSON_WITH_BODY_SITE, OUTPUT_XML_WITH_BODY_SITE)
         );
     }
 }

--- a/service/src/test/resources/ehr/mapper/observation/example-observation-with-body-site.json
+++ b/service/src/test/resources/ehr/mapper/observation/example-observation-with-body-site.json
@@ -1,0 +1,66 @@
+{
+  "resourceType": "Observation",
+  "id": "df265dd8-9afd-11ed-9add-0a58a9feac02",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+    ]
+  },
+  "identifier": [
+    {
+      "system": "https://medicus.health",
+      "value": "df265dd8-9afd-11ed-9add-0a58a9feac02"
+    }
+  ],
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "446063006",
+        "display": "MRI of rib",
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+            "extension": [
+              {
+                "url": "descriptionId",
+                "valueId": "3027809017"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/c168d7d0-9afd-11ed-9c6b-0a58a9feac02"
+  },
+  "effectiveDateTime": "2023-01-23",
+  "issued": "2023-01-23T00:00:00+00:00",
+  "comment": "test additional information",
+  "bodySite": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "60413009",
+        "display": "Thoracic cage structure",
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+            "extension": [
+              {
+                "url": "descriptionId",
+                "valueId": "100385018"
+              },
+              {
+                "url": "descriptionDisplay",
+                "valueString": "Rib cage"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/service/src/test/resources/ehr/mapper/observation/expected-output-observation-with-body-site.xml
+++ b/service/src/test/resources/ehr/mapper/observation/expected-output-observation-with-body-site.xml
@@ -1,0 +1,20 @@
+<component typeCode="COMP" >
+    <ObservationStatement classCode="OBS" moodCode="EVN">
+        <id root="394559384658936" />
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE" />
+        <effectiveTime>
+            <center value="20230123"/>
+        </effectiveTime>
+        <availabilityTime value="20230123"/>
+        
+        
+        <pertinentInformation typeCode="PERT">
+            <sequenceNumber value="+1" />
+            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                <text>test additional information BodySite: Rib cage</text>
+            </pertinentAnnotation>
+        </pertinentInformation>
+        
+    </ObservationStatement>
+</component>


### PR DESCRIPTION
Development Task: When we receive an entry with a Bodysite parameter, we should map the display text of the bodysite to the text/comment section of the parent entry prefixed with “BodySite:”, translating this across into the HL7 format. 

Update Observation statement mapper to map body site correctly 
Add example json to WireMock
Add example test files for parameterised test
Add E2E test for Body Site Mapping