### PR TITLE
NIAD-2499: alternative list reference style

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -19,6 +20,7 @@ import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.DocumentReference;
 import org.hl7.fhir.dstu3.model.Encounter;
+import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Immunization;
 import org.hl7.fhir.dstu3.model.ListResource;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
@@ -28,6 +30,7 @@ import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.ReferralRequest;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.ResourceType;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -76,6 +79,7 @@ public class EncounterComponentsMapper {
     private final DiagnosticReportMapper diagnosticReportMapper;
     private final BloodPressureValidator bloodPressureValidator;
     private final CodeableConceptCdMapper codeableConceptCdMapper;
+
     private final Map<ResourceType, Function<Resource, Optional<String>>> encounterComponents = Map.of(
         ResourceType.AllergyIntolerance, this::mapAllergyIntolerance,
         ResourceType.Condition, this::mapCondition,
@@ -102,6 +106,7 @@ public class EncounterComponentsMapper {
                 (ListResource) messageContext
                     .getInputBundleHolder()
                     .getRequiredResource(reference))
+            .filter(listResource -> CodeableConceptMappingUtils.hasCode(listResource.getCode(), List.of(TOPIC_LIST_CODE)))
             .collect(Collectors.toList());
 
         return topics.stream()
@@ -110,11 +115,6 @@ public class EncounterComponentsMapper {
     }
 
     private String mapTopicListToComponent(ListResource topicList) {
-
-        if (!CodeableConceptMappingUtils.hasCode(topicList.getCode(), List.of(TOPIC_LIST_CODE))) {
-            throw new EhrMapperException(String.format("Unexpected list %s referenced in Consultation, expected list to be coded as "
-                + "Topic (EHR)", topicList.getId()));
-        }
 
         String components = mapTopicListComponents(topicList);
 
@@ -148,6 +148,7 @@ public class EncounterComponentsMapper {
                 .getRequiredResource(reference))
             .filter(resource -> resource.getResourceType().equals(ResourceType.List))
             .map(resource -> (ListResource) resource)
+            .filter(listResource -> CodeableConceptMappingUtils.hasCode(listResource.getCode(), List.of(CATEGORY_LIST_CODE)))
             .map(this::mapCategoryListToComponent)
             .collect(Collectors.joining());
 
@@ -157,11 +158,6 @@ public class EncounterComponentsMapper {
     }
 
     private String mapCategoryListToComponent(ListResource categoryList) {
-
-        if (!CodeableConceptMappingUtils.hasCode(categoryList.getCode(), List.of(CATEGORY_LIST_CODE))) {
-            throw new EhrMapperException(String.format("Unexpected list %s referenced in Topic (EHR), expected list to be coded as "
-                + "Category (EHR)", categoryList.getId()));
-        }
 
         String components = mapListResourceToComponents(categoryList);
 
@@ -208,18 +204,22 @@ public class EncounterComponentsMapper {
             return Optional.empty();
         }
 
-        Resource resource = messageContext.getInputBundleHolder().getRequiredResource(item.getItem().getReferenceElement());
+        var reference = item.getItem().getReferenceElement();
+        if (isListResource(reference)) {
+            return mapResourcesContainedInList(reference, this::mapConsultationListResourceToComponent);
+        }
+
+        Resource resource = messageContext.getInputBundleHolder().getRequiredResource(reference);
+
         LOGGER.debug("Translating list entry resource {}", resource.getId());
+        return mapConsultationListResourceToComponent(resource);
+    }
+
+    private Optional<String> mapConsultationListResourceToComponent(Resource resource) {
         if (encounterComponents.containsKey(resource.getResourceType())) {
             return encounterComponents.get(resource.getResourceType()).apply(resource);
-        } else if (isIgnoredResourceType(resource.getResourceType()) || resource.getResourceType().equals(ResourceType.List)) {
-            // lists referenced within consultations are only mapped as topics or categories
-            // so should be ignored when mapping individual items
-
-            if (!resource.getResourceType().equals(ResourceType.List)) {
-                LOGGER.info(String.format("Resource of type: %s has been ignored", resource.getResourceType()));
-            }
-
+        } else if (isIgnoredResourceType(resource.getResourceType())) {
+            LOGGER.info(String.format("Resource of type: %s has been ignored", resource.getResourceType()));
             return Optional.empty();
         } else {
             throw new EhrMapperException("Unsupported resource in consultation list: " + resource.getId());
@@ -346,5 +346,43 @@ public class EncounterComponentsMapper {
 
     private Encounter findEncounterForList(ListResource listResource) {
         return (Encounter) messageContext.getInputBundleHolder().getRequiredResource(listResource.getEncounter().getReferenceElement());
+    }
+
+    private Optional<String> mapResourcesContainedInList(IIdType fullReference, Function<Resource, Optional<String>> mapperFunction) {
+        var pattern = Pattern.compile("^([\\da-zA-Z-]*)(#[\\da-zA-Z-]*)$");
+        var matcher = pattern.matcher(fullReference.getIdPart());
+
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+
+        var listId = matcher.group(1);
+        var containedResourceId = matcher.group(2);
+
+        var listResource = (ListResource) messageContext.getInputBundleHolder()
+            .getRequiredResource(buildListReference(listId));
+
+        return listResource.getContained().stream()
+            .filter(resource -> resourceHasId(resource, containedResourceId))
+            .map(this::removeNumberSignFromId)
+            .findFirst()
+            .flatMap(mapperFunction);
+    }
+
+    private Resource removeNumberSignFromId(Resource resource) {
+        return resource.setIdElement(new IdType(resource.getResourceType().name(), resource.getId().replace("#", StringUtils.EMPTY)));
+    }
+
+    private boolean resourceHasId(Resource resource, String id) {
+        return resource.hasIdElement() && resource.getIdElement().getValue().equals(id);
+    }
+
+    private IIdType buildListReference(String id) {
+        var referenceString = String.format("%s/%s", ResourceType.List, id);
+        return new Reference(referenceString).getReferenceElement();
+    }
+
+    private boolean isListResource(IIdType reference) {
+        return reference.hasResourceType() && reference.getResourceType().equals(ResourceType.List.name());
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/NonConsultationResourceMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/NonConsultationResourceMapperTest.java
@@ -197,7 +197,8 @@ public class NonConsultationResourceMapperTest {
 
         var mappedResources = resourceArgumentCaptor.getAllValues();
         var mappedResourceTypesInOrder = mappedResources.stream().map(Resource::getResourceType);
-        assertThat(mappedResourceTypesInOrder.collect(Collectors.toList())).isEqualTo(asList(ResourceType.DiagnosticReport, ResourceType.Observation));
+        assertThat(mappedResourceTypesInOrder.collect(Collectors.toList()))
+            .isEqualTo(asList(ResourceType.DiagnosticReport, ResourceType.Observation));
     }
 
     private static Stream<Arguments> testArgs() {

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-not-referenced.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-not-referenced.json
@@ -1,0 +1,721 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325861000000105",
+                "display": "Face to face consultation",
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                    "extension": [
+                      {
+                        "url": "descriptionId",
+                        "valueId": "600731000000118"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "Primary Performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "Recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-23T16:37:00+00:00"
+        },
+        "serviceProvider": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "de10df46-3717-45a9-b49e-c4673e18db19",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "de10df46-3717-45a9-b49e-c4673e18db19"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "788781001",
+                  "display": "Delayed allergy to red meat (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "3785510016"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Delayed allergy to red meat"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-referenced-in-category.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-referenced-in-category.json
@@ -1,0 +1,858 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325861000000105",
+                "display": "Face to face consultation",
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                    "extension": [
+                      {
+                        "url": "descriptionId",
+                        "valueId": "600731000000118"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "Primary Performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "Recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-23T16:37:00+00:00"
+        },
+        "serviceProvider": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02-consultation",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:42:37+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "325851000000107",
+              "display": "Consultation"
+            }
+          ]
+        },
+        "title": "Face to face consultation",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/364a14aa-6b4d-11ed-bb49-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "364a14aa-6b4d-11ed-bb49-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "25851000000105",
+              "display": "Topic (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:38:08+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "Skin Rash",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/400eb266-6b4d-11ed-9e10-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "400eb266-6b4d-11ed-9e10-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "24781000000107",
+              "display": "Category (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "History",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/6f359d7c-4996-4c85-b2c5-af46117d1915#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "de10df46-3717-45a9-b49e-c4673e18db19",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "de10df46-3717-45a9-b49e-c4673e18db19"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "788781001",
+                  "display": "Delayed allergy to red meat (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "3785510016"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Delayed allergy to red meat"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-referenced-in-topic.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-referenced-in-topic.json
@@ -1,0 +1,813 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325861000000105",
+                "display": "Face to face consultation",
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                    "extension": [
+                      {
+                        "url": "descriptionId",
+                        "valueId": "600731000000118"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "Primary Performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "Recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-23T16:37:00+00:00"
+        },
+        "serviceProvider": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02-consultation",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:42:37+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "325851000000107",
+              "display": "Consultation"
+            }
+          ]
+        },
+        "title": "Face to face consultation",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/364a14aa-6b4d-11ed-bb49-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "364a14aa-6b4d-11ed-bb49-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "25851000000105",
+              "display": "Topic (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:38:08+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "Skin Rash",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/6f359d7c-4996-4c85-b2c5-af46117d1915#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "de10df46-3717-45a9-b49e-c4673e18db19",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "de10df46-3717-45a9-b49e-c4673e18db19"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "788781001",
+                  "display": "Delayed allergy to red meat (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "3785510016"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Delayed allergy to red meat"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-referenced-observation.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-referenced-observation.json
@@ -1,0 +1,824 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325861000000105",
+                "display": "Face to face consultation",
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                    "extension": [
+                      {
+                        "url": "descriptionId",
+                        "valueId": "600731000000118"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "Primary Performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "Recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-23T16:37:00+00:00"
+        },
+        "serviceProvider": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02-consultation",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:42:37+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "325851000000107",
+              "display": "Consultation"
+            }
+          ]
+        },
+        "title": "Face to face consultation",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/364a14aa-6b4d-11ed-bb49-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "364a14aa-6b4d-11ed-bb49-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "25851000000105",
+              "display": "Topic (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:38:08+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "Skin Rash",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/400eb266-6b4d-11ed-9e10-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "400eb266-6b4d-11ed-9e10-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "24781000000107",
+              "display": "Category (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "History",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/e5f0c5d4-37f0-4b51-bd25-4296590080e4#B38DF435-D8E5-4D02-8161-55A71E37F684"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "id": "e5f0c5d4-37f0-4b51-bd25-4296590080e4",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "Observation",
+            "id": "B38DF435-D8E5-4D02-8161-55A71E37F684",
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+              ]
+            },
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "B38DF435-D8E5-4D02-8161-55A71E37F684"
+              }
+            ],
+            "status": "final",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://read.info/readv2",
+                  "code": "12C..00",
+                  "display": "FH: Cardiovascular disease",
+                  "userSelected": true
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "397693011"
+                        }
+                      ]
+                    }
+                  ],
+                  "system": "http://snomed.info/sct",
+                  "code": "266894000",
+                  "display": "FH: Cardiovascular disease"
+                }
+              ]
+            },
+            "subject": {
+              "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+            },
+            "effectiveDateTime": "2009-11-02",
+            "issued": "2010-01-13T15:13:32.1+00:00",
+            "performer": [
+              {
+                "reference": "Practitioner/6AB948A5-2067-4A67-AD00-60EAF13E9CAA"
+              }
+            ],
+            "comment": "Family member : Uncle"
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Observation/B38DF435-D8E5-4D02-8161-55A71E37F684"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-topic-and-category.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-topic-and-category.json
@@ -1,0 +1,956 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325861000000105",
+                "display": "Face to face consultation",
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                    "extension": [
+                      {
+                        "url": "descriptionId",
+                        "valueId": "600731000000118"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "Primary Performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "Recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-23T16:37:00+00:00"
+        },
+        "serviceProvider": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02-consultation",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:42:37+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "325851000000107",
+              "display": "Consultation"
+            }
+          ]
+        },
+        "title": "Face to face consultation",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/364a14aa-6b4d-11ed-bb49-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "364a14aa-6b4d-11ed-bb49-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "25851000000105",
+              "display": "Topic (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:38:08+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "Skin Rash",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/400eb266-6b4d-11ed-9e10-0a58a9feac02"
+            }
+          },
+          {
+            "item": {
+              "reference": "List/6f359d7c-4996-4c85-b2c5-af46117d1915#d8d355a1-3955-4ea3-97e7-f8f964d3c2e2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "400eb266-6b4d-11ed-9e10-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "24781000000107",
+              "display": "Category (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "History",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/6f359d7c-4996-4c85-b2c5-af46117d1915#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "de10df46-3717-45a9-b49e-c4673e18db19",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "de10df46-3717-45a9-b49e-c4673e18db19"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "788781001",
+                  "display": "Delayed allergy to red meat (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "3785510016"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Delayed allergy to red meat"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          },
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "d8d355a1-3955-4ea3-97e7-f8f964d3c2e2",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "d8d355a1-3955-4ea3-97e7-f8f964d3c2e2"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "1208807009",
+                  "display": "Allergy to Felis catus protein (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "4971136014"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Allergy to domestic cat protein"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          },
+          {
+            "item": {
+              "reference": "#d8d355a1-3955-4ea3-97e7-f8f964d3c2e2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-two-resources-category.json
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/input-two-resources-category.json
@@ -1,0 +1,956 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+          }
+        ],
+        "status": "finished",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "325861000000105",
+                "display": "Face to face consultation",
+                "extension": [
+                  {
+                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                    "extension": [
+                      {
+                        "url": "descriptionId",
+                        "valueId": "600731000000118"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "Primary Performer"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          },
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                    "code": "REC",
+                    "display": "Recorder"
+                  }
+                ]
+              }
+            ],
+            "individual": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-23T16:37:00+00:00"
+        },
+        "serviceProvider": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "3642bd5e-6b4d-11ed-a206-0a58a9feac02-consultation",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:42:37+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "325851000000107",
+              "display": "Consultation"
+            }
+          ]
+        },
+        "title": "Face to face consultation",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/364a14aa-6b4d-11ed-bb49-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "364a14aa-6b4d-11ed-bb49-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "25851000000105",
+              "display": "Topic (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "date": "2022-11-23T16:38:08+00:00",
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "Skin Rash",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/400eb266-6b4d-11ed-9e10-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "id": "400eb266-6b4d-11ed-9e10-0a58a9feac02",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "24781000000107",
+              "display": "Category (EHR)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "encounter": {
+          "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+        },
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/list-order",
+              "code": "system",
+              "display": "Sorted by System"
+            }
+          ]
+        },
+        "title": "History",
+        "entry": [
+          {
+            "item": {
+              "reference": "List/6f359d7c-4996-4c85-b2c5-af46117d1915#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          },
+          {
+            "item": {
+              "reference": "List/6f359d7c-4996-4c85-b2c5-af46117d1915#d8d355a1-3955-4ea3-97e7-f8f964d3c2e2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "de10df46-3717-45a9-b49e-c4673e18db19",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "de10df46-3717-45a9-b49e-c4673e18db19"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "788781001",
+                  "display": "Delayed allergy to red meat (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "3785510016"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Delayed allergy to red meat"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          },
+          {
+            "resourceType": "AllergyIntolerance",
+            "id": "d8d355a1-3955-4ea3-97e7-f8f964d3c2e2",
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "d8d355a1-3955-4ea3-97e7-f8f964d3c2e2"
+              }
+            ],
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+              ]
+            },
+            "verificationStatus": "unconfirmed",
+            "assertedDate": "2022-11-23T00:00:00+00:00",
+            "onsetDateTime": "2022-07",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "1208807009",
+                  "display": "Allergy to Felis catus protein (finding)",
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "4971136014"
+                        },
+                        {
+                          "url": "descriptionDisplay",
+                          "valueString": "Allergy to domestic cat protein"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "clinicalStatus": "resolved",
+            "patient": {
+              "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+            },
+            "recorder": {
+              "reference": "Practitioner/aebc00c2-28df-11eb-adc1-0242ac120002"
+            },
+            "category": [
+              "environment"
+            ],
+            "note": [
+              {
+                "text": "Certainty: Confirmed by Challenge Testing"
+              }
+            ],
+            "reaction": [
+              {
+                "manifestation": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "271807003",
+                        "display": "Eruption",
+                        "extension": [
+                          {
+                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                            "extension": [
+                              {
+                                "url": "descriptionId",
+                                "valueId": "406765011"
+                              },
+                              {
+                                "url": "descriptionDisplay",
+                                "valueString": "Skin rash"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "severity": "mild"
+              }
+            ]
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#de10df46-3717-45a9-b49e-c4673e18db19"
+            }
+          },
+          {
+            "item": {
+              "reference": "#d8d355a1-3955-4ea3-97e7-f8f964d3c2e2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "Encounter/3642bd5e-6b4d-11ed-a206-0a58a9feac02"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-referenced-in-category.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-referenced-in-category.xml
@@ -1,0 +1,68 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20221123163700"/>
+        </effectiveTime>
+        <availabilityTime value="20221123163808"/>
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20221123163700"/>
+                </effectiveTime>
+                <availabilityTime value="20221123163700"/>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="SN53.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Allergy, unspecified"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="202207"/>
+                        </effectiveTime>
+                        <availabilityTime value="202207"/>
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="ENV">
+                                <id root="394559384658936"/>
+                                <code nullFlavor="UNK">
+                                    <originalText>Mocked code</originalText>
+                                </code>
+                                <statusCode code="COMPLETE"/>
+                                <effectiveTime>
+                                    <center value="202207"/>
+                                </effectiveTime>
+                                <availabilityTime value="202207"/>
+                                <pertinentInformation typeCode="PERT">
+                                    <sequenceNumber value="+1"/>
+                                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                        <text>Status: Resolved Reaction 1 Severity: MILD Manifestation(s): Skin rash
+                                            Certainty: Confirmed by Challenge Testing
+                                        </text>
+                                    </pertinentAnnotation>
+                                </pertinentInformation>
+                                <Participant typeCode="AUT" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                                <Participant typeCode="PRF" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-referenced-in-topic.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-referenced-in-topic.xml
@@ -1,0 +1,55 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20221123163700"/>
+        </effectiveTime>
+        <availabilityTime value="20221123163808"/>
+        <component typeCode="COMP">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code code="SN53.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Allergy, unspecified"/>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="202207"/>
+                </effectiveTime>
+                <availabilityTime value="202207"/>
+                <component typeCode="COMP" contextConductionInd="true">
+                    <ObservationStatement classCode="OBS" moodCode="ENV">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="202207"/>
+                        </effectiveTime>
+                        <availabilityTime value="202207"/>
+                        <pertinentInformation typeCode="PERT">
+                            <sequenceNumber value="+1"/>
+                            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                <text>Status: Resolved Reaction 1 Severity: MILD Manifestation(s): Skin rash Certainty:
+                                    Confirmed by Challenge Testing
+                                </text>
+                            </pertinentAnnotation>
+                        </pertinentInformation>
+                        <Participant typeCode="AUT" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                    </ObservationStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-referenced-observation.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-referenced-observation.xml
@@ -1,0 +1,50 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20221123163700"/>
+        </effectiveTime>
+        <availabilityTime value="20221123163808"/>
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20221123163700"/>
+                </effectiveTime>
+                <availabilityTime value="20221123163700"/>
+                <component typeCode="COMP">
+                    <ObservationStatement classCode="OBS" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="20091102"/>
+                        </effectiveTime>
+                        <availabilityTime value="20091102"/>
+                        <pertinentInformation typeCode="PERT">
+                            <sequenceNumber value="+1"/>
+                            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                <text>Family member : Uncle</text>
+                            </pertinentAnnotation>
+                        </pertinentInformation>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                    </ObservationStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-topic-and-category.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-topic-and-category.xml
@@ -1,0 +1,110 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20221123163700"/>
+        </effectiveTime>
+        <availabilityTime value="20221123163808"/>
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20221123163700"/>
+                </effectiveTime>
+                <availabilityTime value="20221123163700"/>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="SN53.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Allergy, unspecified"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="202207"/>
+                        </effectiveTime>
+                        <availabilityTime value="202207"/>
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="ENV">
+                                <id root="394559384658936"/>
+                                <code nullFlavor="UNK">
+                                    <originalText>Mocked code</originalText>
+                                </code>
+                                <statusCode code="COMPLETE"/>
+                                <effectiveTime>
+                                    <center value="202207"/>
+                                </effectiveTime>
+                                <availabilityTime value="202207"/>
+                                <pertinentInformation typeCode="PERT">
+                                    <sequenceNumber value="+1"/>
+                                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                        <text>Status: Resolved Reaction 1 Severity: MILD Manifestation(s): Skin rash
+                                            Certainty: Confirmed by Challenge Testing
+                                        </text>
+                                    </pertinentAnnotation>
+                                </pertinentInformation>
+                                <Participant typeCode="AUT" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                                <Participant typeCode="PRF" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+        <component typeCode="COMP">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code code="SN53.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Allergy, unspecified"/>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="202207"/>
+                </effectiveTime>
+                <availabilityTime value="202207"/>
+                <component typeCode="COMP" contextConductionInd="true">
+                    <ObservationStatement classCode="OBS" moodCode="ENV">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="202207"/>
+                        </effectiveTime>
+                        <availabilityTime value="202207"/>
+                        <pertinentInformation typeCode="PERT">
+                            <sequenceNumber value="+1"/>
+                            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                <text>Status: Resolved Reaction 1 Severity: MILD Manifestation(s): Skin rash Certainty:
+                                    Confirmed by Challenge Testing
+                                </text>
+                            </pertinentAnnotation>
+                        </pertinentInformation>
+                        <Participant typeCode="AUT" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                    </ObservationStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-two-resources-category.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/contained-resources/output-two-resources-category.xml
@@ -1,0 +1,110 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="TOPIC" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20221123163700"/>
+        </effectiveTime>
+        <availabilityTime value="20221123163808"/>
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20221123163700"/>
+                </effectiveTime>
+                <availabilityTime value="20221123163700"/>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="SN53.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Allergy, unspecified"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="202207"/>
+                        </effectiveTime>
+                        <availabilityTime value="202207"/>
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="ENV">
+                                <id root="394559384658936"/>
+                                <code nullFlavor="UNK">
+                                    <originalText>Mocked code</originalText>
+                                </code>
+                                <statusCode code="COMPLETE"/>
+                                <effectiveTime>
+                                    <center value="202207"/>
+                                </effectiveTime>
+                                <availabilityTime value="202207"/>
+                                <pertinentInformation typeCode="PERT">
+                                    <sequenceNumber value="+1"/>
+                                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                        <text>Status: Resolved Reaction 1 Severity: MILD Manifestation(s): Skin rash
+                                            Certainty: Confirmed by Challenge Testing
+                                        </text>
+                                    </pertinentAnnotation>
+                                </pertinentInformation>
+                                <Participant typeCode="AUT" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                                <Participant typeCode="PRF" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+                <component typeCode="COMP">
+                    <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                        <id root="394559384658936"/>
+                        <code code="SN53.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Allergy, unspecified"/>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="202207"/>
+                        </effectiveTime>
+                        <availabilityTime value="202207"/>
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <ObservationStatement classCode="OBS" moodCode="ENV">
+                                <id root="394559384658936"/>
+                                <code nullFlavor="UNK">
+                                    <originalText>Mocked code</originalText>
+                                </code>
+                                <statusCode code="COMPLETE"/>
+                                <effectiveTime>
+                                    <center value="202207"/>
+                                </effectiveTime>
+                                <availabilityTime value="202207"/>
+                                <pertinentInformation typeCode="PERT">
+                                    <sequenceNumber value="+1"/>
+                                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                        <text>Status: Resolved Reaction 1 Severity: MILD Manifestation(s): Skin rash
+                                            Certainty: Confirmed by Challenge Testing
+                                        </text>
+                                    </pertinentAnnotation>
+                                </pertinentInformation>
+                                <Participant typeCode="AUT" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                                <Participant typeCode="PRF" contextControlCode="OP">
+                                    <agentRef classCode="AGNT">
+                                        <id root="394559384658936"/>
+                                    </agentRef>
+                                </Participant>
+                            </ObservationStatement>
+                        </component>
+                    </CompoundStatement>
+                </component>
+            </CompoundStatement>
+        </component>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/non_consultation_bundles/contained-miscellaneous-records-bundle.json
+++ b/service/src/test/resources/ehr/mapper/non_consultation_bundles/contained-miscellaneous-records-bundle.json
@@ -1,0 +1,606 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "id": "e5f0c5d4-37f0-4b51-bd25-4296590080e4",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "Observation",
+            "id": "B38DF435-D8E5-4D02-8161-55A71E37F684",
+            "meta": {
+              "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+              ]
+            },
+            "identifier": [
+              {
+                "system": "https://medicus.health",
+                "value": "B38DF435-D8E5-4D02-8161-55A71E37F684"
+              }
+            ],
+            "status": "final",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://read.info/readv2",
+                  "code": "12C..00",
+                  "display": "FH: Cardiovascular disease",
+                  "userSelected": true
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "397693011"
+                        }
+                      ]
+                    }
+                  ],
+                  "system": "http://snomed.info/sct",
+                  "code": "266894000",
+                  "display": "FH: Cardiovascular disease"
+                }
+              ]
+            },
+            "subject": {
+              "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+            },
+            "effectiveDateTime": "2009-11-02",
+            "issued": "2010-01-13T15:13:32.1+00:00",
+            "performer": [
+              {
+                "reference": "Practitioner/6AB948A5-2067-4A67-AD00-60EAF13E9CAA"
+              }
+            ],
+            "comment": "Family member : Uncle"
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#B38DF435-D8E5-4D02-8161-55A71E37F684"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/non_consultation_bundles/contained-unknown-resource-bundle.json
+++ b/service/src/test/resources/ehr/mapper/non_consultation_bundles/contained-unknown-resource-bundle.json
@@ -1,0 +1,560 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "AEED4157-E1D7-4AB9-B628-43F366B40274",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "51dd7b16-6b44-11ed-a02d-0a58a9feac02",
+        "meta": {
+          "versionId": "ff01c0199a7079a6bbdc035bfc755419",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "2022-11-23"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9727180310"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "BANG",
+            "prefix": [
+              "MR"
+            ],
+            "given": [
+              "Colin",
+              "Ramon"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "2022-05-05",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "1 DRURY LANE",
+              "NORTH SHIELDS",
+              "TYNE & WEAR"
+            ],
+            "postalCode": "NE29 8SJ",
+            "country": "GBR"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/B84012"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "B84012",
+        "meta": {
+          "versionId": "29f8da7af7c6b1c51b9cd3f89d25006a",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "B84012"
+          }
+        ],
+        "active": true,
+        "name": "Spring Hall Group Practice",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "aebc00c2-28df-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "36304757d4fe25a6f3cc15ac99d05561",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "given": "Mohammed",
+            "family":"Lee",
+            "prefix":"Mr"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "id": "6f359d7c-4996-4c85-b2c5-af46117d1915",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+
+      }
+    },
+    {
+      "resource": {
+        "id": "e5f0c5d4-37f0-4b51-bd25-4296590080e4",
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "contained": [
+          {
+            "resourceType": "TestReport",
+            "id": "f691cc62-d537-4215-9b46-bdd1e6222efe",
+            "status": "completed",
+            "name": "Unsupported Resource",
+            "result": "pass"
+          }
+        ],
+        "entry": [
+          {
+            "item": {
+              "reference": "#f691cc62-d537-4215-9b46-bdd1e6222efe"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/51dd7b16-6b44-11ed-a02d-0a58a9feac02"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/non_consultation_bundles/expected-miscellaneous-records-output.xml
+++ b/service/src/test/resources/ehr/mapper/non_consultation_bundles/expected-miscellaneous-records-output.xml
@@ -1,0 +1,46 @@
+<component typeCode="COMP">
+    <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+        <id root="b2175be3-29c2-465f-b2c6-323db03c2c7c" />
+        <code code="196401000000100" displayName="Non-consultation data" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+        <statusCode code="COMPLETE" />
+        <effectiveTime>
+            <center value="20091102"/>
+        </effectiveTime>
+        <availabilityTime value="20091102"/>
+        <author typeCode="AUT" contextControlCode="OP">
+            <time value="20091102" />
+            <agentRef classCode="AGNT">
+                <id root="394559384658936" />
+            </agentRef>
+        </author>
+        <Participant2 typeCode="PRF" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root="394559384658936"/>
+            </agentRef>
+        </Participant2>
+        <component typeCode="COMP">
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>Mocked code</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20091102"/>
+                </effectiveTime>
+                <availabilityTime value="20091102"/>
+                <pertinentInformation typeCode="PERT">
+                    <sequenceNumber value="+1"/>
+                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                        <text>Family member : Uncle</text>
+                    </pertinentAnnotation>
+                </pertinentInformation>
+                <Participant typeCode="PRF" contextControlCode="OP">
+                    <agentRef classCode="AGNT">
+                        <id root="394559384658936"/>
+                    </agentRef>
+                </Participant>
+            </ObservationStatement>
+        </component>
+    </ehrComposition>
+</component>

--- a/service/src/test/resources/ehr/mapper/non_consultation_bundles/observation-statement-stub.xml
+++ b/service/src/test/resources/ehr/mapper/non_consultation_bundles/observation-statement-stub.xml
@@ -1,0 +1,24 @@
+<component typeCode="COMP">
+    <ObservationStatement classCode="OBS" moodCode="EVN">
+        <id root="394559384658936"/>
+        <code nullFlavor="UNK">
+            <originalText>Mocked code</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20091102"/>
+        </effectiveTime>
+        <availabilityTime value="20091102"/>
+        <pertinentInformation typeCode="PERT">
+            <sequenceNumber value="+1"/>
+            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                <text>Family member : Uncle</text>
+            </pertinentAnnotation>
+        </pertinentInformation>
+        <Participant typeCode="PRF" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root="394559384658936"/>
+            </agentRef>
+        </Participant>
+    </ObservationStatement>
+</component>


### PR DESCRIPTION
### Description

Examples Allergy Intolerances referenced locally in a list could not be refenced in other components. Add support for referencing resources in the contained field of a list.  Referenced in the form:

*In list reference : #2e450b08-6b51-11ed-af8f-0a58a9feac02*
*Outside list: List/{ListID}#2e450b08-6b51-11ed-af8f-0a58a9feac02* 

### Work done

- map all supported resources if they follow the *contained in list* referencing style  
- map resources referenced in a consultation to components in the consultation structure
- map resources that are only referenced locally in a list to the non-consultation structure