### PR TITLE
NIAD-2653: Bug Fix - NACK codes should be 2 digit strings

### DIFF
--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -100,7 +100,7 @@ public class EhrExtractTest {
     private static final String ACK_TO_PENDING = "ackPending";
     private static final String NACK_CODE_FAILED_TO_GENERATE_EHR = "10";
     private final static String NACK_CODE_REQUEST_NOT_WELL_FORMED = "18";
-    private final static String NACK_CODE_PATIENT_NOT_FOUND = "6";
+    private final static String NACK_CODE_PATIENT_NOT_FOUND = "06";
     private final static String NACK_CODE_INVALID = "19";
     private final static String NACK_CODE_GP_CONNECT_ERROR = "20";
     private final static String NACK_MESSAGE_REQUEST_NOT_WELL_FORMED = "An error occurred processing the initial EHR request";

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/ProcessingErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/ProcessingErrorHandler.java
@@ -58,7 +58,7 @@ public class ProcessingErrorHandler {
     public boolean handleNotFoundError(TaskDefinition taskDefinition) {
         return handleFailingProcess(
                 taskDefinition,
-                "6",
+                "06",
                 "Patient not at surgery."
         );
     }


### PR DESCRIPTION
NACK codes below 10 should be prepended with a 0, i.e. 06