### PR TITLE
NIAD-2726: BIG_FIX external attachments limit

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -86,6 +86,8 @@ dependencies {
 	testImplementation 'org.awaitility:awaitility:4.0.3'
 	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
 	testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.27.2'
+	testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
 
 	// upgraded to fix SNYK-JAVA-ORGAPACHECOMMONS-3043138
 	spotbugs 'com.github.spotbugs:spotbugs:4.7.3'

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/mhs/MhsWebClientTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/mhs/MhsWebClientTest.java
@@ -1,0 +1,147 @@
+package uk.nhs.adaptors.gp2gp.mhs;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import uk.nhs.adaptors.gp2gp.common.exception.MaximumExternalAttachmentsException;
+import uk.nhs.adaptors.gp2gp.mhs.exception.MhsServerErrorException;
+import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
+
+@SpringBootTest
+@ExtendWith({SpringExtension.class, MockitoExtension.class, MongoDBExtension.class})
+@DirtiesContext
+public class MhsWebClientTest {
+
+    private static final String TEST_BODY = "test body";
+    private static final String TEST_CONVERSATION_ID = "test conversation id";
+    private static final String TEST_FROM_ODS_CODE = "test from ods code";
+    private static final String TEST_MESSAGE_ID = "test message id";
+
+    public static MockWebServer mockWebServer;
+
+    @Autowired
+    private MhsRequestBuilder mhsRequestBuilder;
+    @Autowired
+    private MhsClient mhsClient;
+
+    @SpyBean
+    private MhsConfiguration mhsConfiguration;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @BeforeEach
+    void initialise() {
+        String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
+        when(mhsConfiguration.getUrl()).thenReturn(baseUrl);
+    }
+
+    @Test
+    public void When_SendMessageToMHS_With_400AndMaxExternalAttachments_Expect_CorrectException() {
+        MockResponse response = new MockResponse();
+        response
+            .addHeader("Content-Type", "application/json")
+            .setResponseCode(400)
+            .setBody("{\"external_attachments\": [\"Longer than maximum length 99.\"]}");
+
+        mockWebServer.enqueue(response);
+
+        var request = mhsRequestBuilder.buildSendEhrExtractCoreRequest(TEST_BODY,
+            TEST_CONVERSATION_ID, TEST_FROM_ODS_CODE, TEST_MESSAGE_ID);
+
+        assertThatThrownBy(() -> mhsClient.sendMessageToMHS(request))
+            .isInstanceOf(MaximumExternalAttachmentsException.class);
+    }
+
+    @Test
+    public void When_SendMessageToMHS_With_400AndOtherValidationErrors_Expect_CorrectException() {
+        MockResponse response = new MockResponse();
+        response
+            .addHeader("Content-Type", "application/json")
+            .setResponseCode(400)
+            .setBody("{\"unknown_verification_error\": [\"test problem.\"]}");
+
+        mockWebServer.enqueue(response);
+
+        var request = mhsRequestBuilder.buildSendEhrExtractCoreRequest(TEST_BODY,
+            TEST_CONVERSATION_ID, TEST_FROM_ODS_CODE, TEST_MESSAGE_ID);
+
+        assertThatThrownBy(() -> mhsClient.sendMessageToMHS(request))
+            .isInstanceOf(InvalidOutboundMessageException.class);
+    }
+
+    @Test
+    public void When_SendMessageToMHS_With_400AndInvalidJson_Expect_CorrectException() {
+        MockResponse response = new MockResponse();
+        response
+            .addHeader("Content-Type", "application/json")
+            .setResponseCode(400)
+            .setBody("Invalid JSON body");
+
+        mockWebServer.enqueue(response);
+
+        var request = mhsRequestBuilder.buildSendEhrExtractCoreRequest(TEST_BODY,
+            TEST_CONVERSATION_ID, TEST_FROM_ODS_CODE, TEST_MESSAGE_ID);
+
+        assertThatThrownBy(() -> mhsClient.sendMessageToMHS(request))
+            .isInstanceOf(InvalidOutboundMessageException.class);
+    }
+
+    @Test
+    public void When_SendMessageToMHS_With_404_Expect_CorrectException() {
+        MockResponse response = new MockResponse();
+        response
+            .addHeader("Content-Type", "application/json")
+            .setResponseCode(404)
+            .setBody("Not found");
+
+        mockWebServer.enqueue(response);
+
+        var request = mhsRequestBuilder.buildSendEhrExtractCoreRequest(TEST_BODY,
+            TEST_CONVERSATION_ID, TEST_FROM_ODS_CODE, TEST_MESSAGE_ID);
+
+        assertThatThrownBy(() -> mhsClient.sendMessageToMHS(request))
+            .isInstanceOf(InvalidOutboundMessageException.class);
+    }
+
+    @Test
+    public void When_SendMessageToMHS_With_5xx_Expect_CorrectException() {
+        MockResponse response = new MockResponse();
+        response
+            .addHeader("Content-Type", "application/json")
+            .setResponseCode(500)
+            .setBody("Server Error");
+
+        mockWebServer.enqueue(response);
+
+        var request = mhsRequestBuilder.buildSendEhrExtractCoreRequest(TEST_BODY,
+            TEST_CONVERSATION_ID, TEST_FROM_ODS_CODE, TEST_MESSAGE_ID);
+
+        assertThatThrownBy(() -> mhsClient.sendMessageToMHS(request))
+            .isInstanceOf(MhsServerErrorException.class);
+    }
+}

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/mhs/MhsWebClientTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/mhs/MhsWebClientTest.java
@@ -2,6 +2,9 @@ package uk.nhs.adaptors.gp2gp.mhs;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import java.io.IOException;
 
@@ -33,7 +36,7 @@ public class MhsWebClientTest {
     private static final String TEST_FROM_ODS_CODE = "test from ods code";
     private static final String TEST_MESSAGE_ID = "test message id";
 
-    public static MockWebServer mockWebServer;
+    private static MockWebServer mockWebServer;
 
     @Autowired
     private MhsRequestBuilder mhsRequestBuilder;
@@ -44,28 +47,28 @@ public class MhsWebClientTest {
     private MhsConfiguration mhsConfiguration;
 
     @BeforeAll
-    static void setup() throws IOException {
+    public static void setup() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
     }
 
     @AfterAll
-    static void tearDown() throws IOException {
+    public static void tearDown() throws IOException {
         mockWebServer.shutdown();
     }
 
     @BeforeEach
-    void initialise() {
+    public void initialise() {
         String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
         when(mhsConfiguration.getUrl()).thenReturn(baseUrl);
     }
 
     @Test
-    public void When_SendMessageToMHS_With_400AndMaxExternalAttachments_Expect_CorrectException() {
+    public void When_SendMessageToMHS_With_HttpStatus400AndMaxExternalAttachments_Expect_CorrectException() {
         MockResponse response = new MockResponse();
         response
             .addHeader("Content-Type", "application/json")
-            .setResponseCode(400)
+            .setResponseCode(BAD_REQUEST.value())
             .setBody("{\"external_attachments\": [\"Longer than maximum length 99.\"]}");
 
         mockWebServer.enqueue(response);
@@ -78,11 +81,11 @@ public class MhsWebClientTest {
     }
 
     @Test
-    public void When_SendMessageToMHS_With_400AndOtherValidationErrors_Expect_CorrectException() {
+    public void When_SendMessageToMHS_With_HttpStatus400AndOtherValidationErrors_Expect_CorrectException() {
         MockResponse response = new MockResponse();
         response
             .addHeader("Content-Type", "application/json")
-            .setResponseCode(400)
+            .setResponseCode(BAD_REQUEST.value())
             .setBody("{\"unknown_verification_error\": [\"test problem.\"]}");
 
         mockWebServer.enqueue(response);
@@ -95,11 +98,11 @@ public class MhsWebClientTest {
     }
 
     @Test
-    public void When_SendMessageToMHS_With_400AndInvalidJson_Expect_CorrectException() {
+    public void When_SendMessageToMHS_With_HttpStatus400AndInvalidJson_Expect_CorrectException() {
         MockResponse response = new MockResponse();
         response
             .addHeader("Content-Type", "application/json")
-            .setResponseCode(400)
+            .setResponseCode(BAD_REQUEST.value())
             .setBody("Invalid JSON body");
 
         mockWebServer.enqueue(response);
@@ -112,11 +115,11 @@ public class MhsWebClientTest {
     }
 
     @Test
-    public void When_SendMessageToMHS_With_404_Expect_CorrectException() {
+    public void When_SendMessageToMHS_With_HttpStatus404_Expect_CorrectException() {
         MockResponse response = new MockResponse();
         response
             .addHeader("Content-Type", "application/json")
-            .setResponseCode(404)
+            .setResponseCode(NOT_FOUND.value())
             .setBody("Not found");
 
         mockWebServer.enqueue(response);
@@ -129,11 +132,11 @@ public class MhsWebClientTest {
     }
 
     @Test
-    public void When_SendMessageToMHS_With_5xx_Expect_CorrectException() {
+    public void When_SendMessageToMHS_With_HttpStatus5xx_Expect_CorrectException() {
         MockResponse response = new MockResponse();
         response
             .addHeader("Content-Type", "application/json")
-            .setResponseCode(500)
+            .setResponseCode(INTERNAL_SERVER_ERROR.value())
             .setBody("Server Error");
 
         mockWebServer.enqueue(response);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/exception/MaximumExternalAttachmentsException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/exception/MaximumExternalAttachmentsException.java
@@ -1,0 +1,7 @@
+package uk.nhs.adaptors.gp2gp.common.exception;
+
+public class MaximumExternalAttachmentsException extends RuntimeException {
+    public MaximumExternalAttachmentsException(String message) {
+        super(message);
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/WebClientFilterService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/WebClientFilterService.java
@@ -75,7 +75,7 @@ public class WebClientFilterService {
             if (requestType.equals(RequestType.MHS_OUTBOUND) && clientResponse.statusCode().is5xxServerError()) {
                 return Mono.error(new MhsServerErrorException("MHS responded with status code " + clientResponse.statusCode().value()));
             }
-            if (requestType.equals(RequestType.MHS_OUTBOUND) && clientResponse.statusCode().value() == 400) {
+            if (requestType.equals(RequestType.MHS_OUTBOUND) && clientResponse.statusCode().value() == BAD_REQUEST.value()) {
                 return clientResponse.bodyToMono(String.class)
                     .flatMap(WebClientFilterService::handle400FromMhsOutbound);
             }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/ProcessingErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/ProcessingErrorHandler.java
@@ -1,21 +1,45 @@
 package uk.nhs.adaptors.gp2gp.common.task;
 
+import java.util.Map;
+import java.util.function.Function;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.nhs.adaptors.gp2gp.common.exception.FhirValidationException;
 import uk.nhs.adaptors.gp2gp.common.service.ProcessFailureHandlingService;
 import uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
+import uk.nhs.adaptors.gp2gp.gpc.exception.EhrRequestException;
+import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectException;
+import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectInvalidException;
+import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectNotFoundException;
 
 @Component
 @Slf4j
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class ProcessingErrorHandler {
 
+    private final Map<Class<? extends Exception>, Function<TaskDefinition, Boolean>> errorHandlers = Map.of(
+        EhrRequestException.class, this::handleRequestError,
+        EhrExtractException.class, this::handleTranslationError,
+        EhrMapperException.class, this::handleTranslationError,
+        FhirValidationException.class, this::handleTranslationError,
+        GpConnectException.class, this::handleGpConnectError,
+        GpConnectInvalidException.class, this::handleInvalidNotAuthError,
+        GpConnectNotFoundException.class, this::handleNotFoundError
+    );
+
     private final ProcessFailureHandlingService processFailureHandlingService;
 
-    public boolean handleRequestError(TaskDefinition taskDefinition) {
+    public boolean handleProcessingError(Exception exception, TaskDefinition taskDefinition) {
+        return errorHandlers.getOrDefault(exception.getClass(), this::handleGeneralProcessingError).apply(taskDefinition);
+    }
+
+    private boolean handleRequestError(TaskDefinition taskDefinition) {
 
         return handleFailingProcess(
             taskDefinition,
@@ -24,7 +48,7 @@ public class ProcessingErrorHandler {
         );
     }
 
-    public boolean handleTranslationError(TaskDefinition taskDefinition) {
+    private boolean handleTranslationError(TaskDefinition taskDefinition) {
         return handleFailingProcess(
             taskDefinition,
             "10",
@@ -32,7 +56,7 @@ public class ProcessingErrorHandler {
         );
     }
 
-    public boolean handleGeneralProcessingError(TaskDefinition taskDefinition) {
+    private boolean handleGeneralProcessingError(TaskDefinition taskDefinition) {
         return handleFailingProcess(
             taskDefinition,
             "99",
@@ -40,7 +64,7 @@ public class ProcessingErrorHandler {
         );
     }
 
-    public boolean handleGpConnectError(TaskDefinition taskDefinition) {
+    private boolean handleGpConnectError(TaskDefinition taskDefinition) {
         return handleFailingProcess(
             taskDefinition,
             "20",
@@ -48,14 +72,14 @@ public class ProcessingErrorHandler {
         );
     }
 
-    public boolean handleInvalidNotAuthError(TaskDefinition taskDefinition) {
+    private boolean handleInvalidNotAuthError(TaskDefinition taskDefinition) {
         return handleFailingProcess(
                 taskDefinition,
                 "19",
                 "Sender check indicates that Requester is not the patient’s current healthcare provider"
         );
     }
-    public boolean handleNotFoundError(TaskDefinition taskDefinition) {
+    private boolean handleNotFoundError(TaskDefinition taskDefinition) {
         return handleFailingProcess(
                 taskDefinition,
                 "06",

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.gp2gp.common.exception.FhirValidationException;
+import uk.nhs.adaptors.gp2gp.common.exception.MaximumExternalAttachmentsException;
 import uk.nhs.adaptors.gp2gp.common.service.ProcessFailureHandlingService;
 import uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
@@ -30,7 +31,8 @@ public class TaskErrorHandler {
         FhirValidationException.class, this::handleTranslationError,
         GpConnectException.class, this::handleGpConnectError,
         GpConnectInvalidException.class, this::handleInvalidNotAuthError,
-        GpConnectNotFoundException.class, this::handleNotFoundError
+        GpConnectNotFoundException.class, this::handleNotFoundError,
+        MaximumExternalAttachmentsException.class, this::handleMaximumExternalAttachmentsError
     );
 
     private final ProcessFailureHandlingService processFailureHandlingService;
@@ -84,6 +86,14 @@ public class TaskErrorHandler {
                 taskDefinition,
                 "06",
                 "Patient not at surgery."
+        );
+    }
+
+    private boolean handleMaximumExternalAttachmentsError(TaskDefinition taskDefinition) {
+        return handleFailingProcess(
+            taskDefinition,
+            "30",
+            "Large Message general failure"
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandler.java
@@ -21,7 +21,7 @@ import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectNotFoundException;
 @Component
 @Slf4j
 @AllArgsConstructor(onConstructor = @__(@Autowired))
-public class ProcessingErrorHandler {
+public class TaskErrorHandler {
 
     private final Map<Class<? extends Exception>, Function<TaskDefinition, Boolean>> errorHandlers = Map.of(
         EhrRequestException.class, this::handleRequestError,

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandler.java
@@ -93,7 +93,7 @@ public class TaskErrorHandler {
         return handleFailingProcess(
             taskDefinition,
             "30",
-            "Large Message general failure"
+            "Maximum external attachment limit reached"
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandler.java
@@ -25,7 +25,7 @@ public class TaskHandler {
     private final TaskExecutorFactory taskExecutorFactory;
     private final MDCService mdcService;
     private final ProcessFailureHandlingService processFailureHandlingService;
-    private final ProcessingErrorHandler processingErrorHandler;
+    private final TaskErrorHandler taskErrorHandler;
 
     /**
      * @return True if the message has been processed. Otherwise, false.
@@ -58,7 +58,7 @@ public class TaskHandler {
             return false;
         } catch (Exception e) {
             logError(e, message);
-            return processingErrorHandler.handleProcessingError(e, taskDefinition);
+            return taskErrorHandler.handleProcessingError(e, taskDefinition);
         }
     }
     @SneakyThrows

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandler.java
@@ -10,16 +10,9 @@ import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.gp2gp.common.amqp.JmsReader;
-import uk.nhs.adaptors.gp2gp.common.exception.FhirValidationException;
 import uk.nhs.adaptors.gp2gp.common.service.MDCService;
 import uk.nhs.adaptors.gp2gp.common.service.ProcessFailureHandlingService;
 import uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition;
-import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
-import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.EhrRequestException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectInvalidException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectNotFoundException;
 import uk.nhs.adaptors.gp2gp.mhs.exception.MhsConnectionException;
 
 @Component
@@ -63,24 +56,9 @@ public class TaskHandler {
         } catch (TaskHandlerException e) {
             logError(e, message);
             return false;
-        } catch (EhrRequestException e) {
-            logError(e, message);
-            return processingErrorHandler.handleRequestError(taskDefinition);
-        } catch (EhrExtractException | EhrMapperException | FhirValidationException e) {
-            logError(e, message);
-            return processingErrorHandler.handleTranslationError(taskDefinition);
-        } catch (GpConnectException e) {
-            logError(e, message);
-            return processingErrorHandler.handleGpConnectError(taskDefinition);
-        } catch (GpConnectInvalidException e) {
-            logError(e, message);
-            return processingErrorHandler.handleInvalidNotAuthError(taskDefinition);
-        } catch (GpConnectNotFoundException e) {
-            logError(e, message);
-            return processingErrorHandler.handleNotFoundError(taskDefinition);
         } catch (Exception e) {
             logError(e, message);
-            return processingErrorHandler.handleGeneralProcessingError(taskDefinition);
+            return processingErrorHandler.handleProcessingError(e, taskDefinition);
         }
     }
     @SneakyThrows

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.quality.Strictness;
 
 import lombok.SneakyThrows;
 import uk.nhs.adaptors.gp2gp.common.exception.FhirValidationException;
+import uk.nhs.adaptors.gp2gp.common.exception.MaximumExternalAttachmentsException;
 import uk.nhs.adaptors.gp2gp.common.service.ProcessFailureHandlingService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
@@ -207,6 +208,26 @@ public class TaskErrorHandlerTest {
 
         assertTrue(taskErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition));
         assertFalse(taskErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+    }
+
+    @Test
+    public void When_HandleProcessingError_WithMaximumExternalAttachmentsException_Expect_ProcessToBeFailedWithCorrectCode() {
+        taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+
+        verify(processFailureHandlingService).failProcess(
+            any(),
+            eq("30"),
+            eq("Large Message general failure"),
+            any());
+    }
+
+    @Test
+    public void When_HandleProcessingError_WithMaximumExternalAttachmentsException_Expect_ReturnValueOfFailService() {
+        when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
+            .thenReturn(true, false);
+
+        assertTrue(taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
@@ -217,7 +217,7 @@ public class TaskErrorHandlerTest {
         verify(processFailureHandlingService).failProcess(
             any(),
             eq("30"),
-            eq("Large Message general failure"),
+            eq("Maximum external attachment limit reached"),
             any());
     }
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
@@ -32,7 +32,7 @@ import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectInvalidException;
 import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
-public class ProcessingErrorHandlerTest {
+public class TaskErrorHandlerTest {
     private static final String TEST_EXCEPTION_MESSAGE = "Test Exception";
 
     @Mock
@@ -42,7 +42,7 @@ public class ProcessingErrorHandlerTest {
     private ProcessFailureHandlingService processFailureHandlingService;
 
     @InjectMocks
-    private ProcessingErrorHandler processingErrorHandler;
+    private TaskErrorHandler taskErrorHandler;
 
     @BeforeEach
     public void setup() {
@@ -51,7 +51,7 @@ public class ProcessingErrorHandlerTest {
 
     @Test
     public void When_HandleProcessingError_WithEhrRequestException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new EhrRequestException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+        taskErrorHandler.handleProcessingError(new EhrRequestException(TEST_EXCEPTION_MESSAGE), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -65,13 +65,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new EhrRequestException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new EhrRequestException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new EhrRequestException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new EhrRequestException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_With_EhrExtractException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new EhrExtractException("Test Exception"), taskDefinition);
+        taskErrorHandler.handleProcessingError(new EhrExtractException("Test Exception"), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -85,13 +85,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new EhrExtractException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new EhrExtractException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new EhrExtractException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new EhrExtractException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_WithEhrMapperException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new EhrMapperException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+        taskErrorHandler.handleProcessingError(new EhrMapperException(TEST_EXCEPTION_MESSAGE), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -105,13 +105,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new EhrMapperException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new EhrMapperException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new EhrMapperException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new EhrMapperException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_WithFhirValidationException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new FhirValidationException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+        taskErrorHandler.handleProcessingError(new FhirValidationException(TEST_EXCEPTION_MESSAGE), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -125,13 +125,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new FhirValidationException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new FhirValidationException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new FhirValidationException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new FhirValidationException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_WithOtherException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new Exception(), taskDefinition);
+        taskErrorHandler.handleProcessingError(new Exception(), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -145,13 +145,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new Exception(), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new Exception(), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new Exception(), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new Exception(), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_WithGpConnectException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new GpConnectException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+        taskErrorHandler.handleProcessingError(new GpConnectException(TEST_EXCEPTION_MESSAGE), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -165,13 +165,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new GpConnectException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new GpConnectException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new GpConnectException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new GpConnectException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_WithGpConnectInvalidException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+        taskErrorHandler.handleProcessingError(new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -185,13 +185,13 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     public void When_HandleProcessingError_WithGpConnectGpConnectNotFoundException_Expect_ProcessToBeFailedWithCorrectCode() {
-        processingErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition);
+        taskErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition);
 
         verify(processFailureHandlingService).failProcess(
             any(),
@@ -205,14 +205,14 @@ public class ProcessingErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(processingErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(processingErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(taskErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertFalse(taskErrorHandler.handleProcessingError(new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE), taskDefinition));
     }
 
     @Test
     @MockitoSettings(strictness = Strictness.LENIENT)
     public void When_HandleGeneralProcessingError_WithNullParameter_Expect_ProcessIsNotFailed() {
-        processingErrorHandler.handleProcessingError(new RuntimeException(), null);
+        taskErrorHandler.handleProcessingError(new RuntimeException(), null);
 
         verifyNoInteractions(processFailureHandlingService);
     }
@@ -224,7 +224,7 @@ public class ProcessingErrorHandlerTest {
             any(), any(), any(), any());
 
         assertThatThrownBy(
-            () -> processingErrorHandler.handleProcessingError(new RuntimeException(), taskDefinition)
+            () -> taskErrorHandler.handleProcessingError(new RuntimeException(), taskDefinition)
         ).isSameAs(failureHandlingException);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskErrorHandlerTest.java
@@ -226,8 +226,12 @@ public class TaskErrorHandlerTest {
         when(processFailureHandlingService.failProcess(any(), any(), any(), any()))
             .thenReturn(true, false);
 
-        assertTrue(taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition));
-        assertFalse(taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition));
+        assertTrue(
+            taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition)
+        );
+        assertFalse(
+            taskErrorHandler.handleProcessingError(new MaximumExternalAttachmentsException(TEST_EXCEPTION_MESSAGE), taskDefinition)
+        );
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandlerTest.java
@@ -25,19 +25,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessResourceFailureException;
 
 import lombok.SneakyThrows;
-import uk.nhs.adaptors.gp2gp.common.exception.FhirValidationException;
-import uk.nhs.adaptors.gp2gp.common.exception.GeneralProcessingException;
 import uk.nhs.adaptors.gp2gp.common.service.MDCService;
 import uk.nhs.adaptors.gp2gp.common.service.ProcessFailureHandlingService;
 import uk.nhs.adaptors.gp2gp.ehr.SendAcknowledgementTaskDefinition;
 import uk.nhs.adaptors.gp2gp.ehr.SendDocumentTaskDefinition;
-import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
-import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.EhrRequestException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectInvalidException;
-import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectNotFoundException;
 import uk.nhs.adaptors.gp2gp.mhs.exception.MhsConnectionException;
-import uk.nhs.adaptors.gp2gp.mhs.exception.MhsServerErrorException;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 @ExtendWith(MockitoExtension.class)
@@ -234,72 +226,6 @@ public class TaskHandlerTest {
 
     @Test
     @SneakyThrows
-    public void When_Handle_WithExecuteThrowsEhrExtractException_Expect_ErrorHandled() {
-        setUpContinueMessage();
-        Exception exception = new EhrExtractException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-    }
-
-    @Test
-    @SneakyThrows
-    public void When_Handle_WithExecuteThrowsEhrMapperException_Expect_ErrorHandled() {
-        setUpContinueMessage();
-        Exception exception = new EhrMapperException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-    }
-
-    @Test
-    @SneakyThrows
-    public void When_Handle_WithExecuteThrowFhirValidationException_Expect_ErrorHandled() {
-        setUpContinueMessage();
-        Exception exception = new FhirValidationException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-    }
-
-
-    @Test
-    @SneakyThrows
-    public void When_Handle_WithExecuteThrowsEhrRequestException_Expect_ErrorHandled() {
-        setUpContinueMessage();
-        Exception exception = new EhrRequestException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-    }
-
-    @Test
-    @SneakyThrows
-    public void When_Handle_WithExecuteThrowsGeneralProcessingException_Expect_ErrorHandled() {
-        setUpContinueMessage();
-        Exception exception = new GeneralProcessingException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-    }
-
-    @Test
-    @SneakyThrows
     public void When_Handle_WithExecuteThrows_MhsConnectionException_Expect_ExceptionThrown() {
         setUpContinueMessage();
         doThrow(new MhsConnectionException("test exception")).when(taskExecutor).execute(any());
@@ -318,36 +244,9 @@ public class TaskHandlerTest {
 
     @Test
     @SneakyThrows
-    public void When_Handle_WithMhsServerErrorException_Expect_ProcessFailed() {
+    public void When_Handle_WithOtherRuntimeException_Expect_ProcessFailed() {
         setUpContinueMessage();
-        Exception exception = new MhsServerErrorException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-
-    }
-
-    @Test
-    @SneakyThrows
-    public void When_Handle_WithGpConnectInvalidException_Expect_ProcessFailed() {
-        setUpContinueMessage();
-        Exception exception = new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE);
-        doThrow(exception).when(taskExecutor).execute(any());
-
-        var result = taskHandler.handle(message);
-        assertThat(result).isFalse();
-
-        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
-    }
-
-    @Test
-    @SneakyThrows
-    public void When_Handle_WithGpConnectNotFoundException_Expect_ProcessFailed() {
-        setUpContinueMessage();
-        Exception exception = new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE);
+        Exception exception = new RuntimeException(TEST_EXCEPTION_MESSAGE);
         doThrow(exception).when(taskExecutor).execute(any());
 
         var result = taskHandler.handle(message);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandlerTest.java
@@ -332,7 +332,7 @@ public class TaskHandlerTest {
 
     @Test
     @SneakyThrows
-    public void When_handle_WithGpConnectInvalidException_Expect_ProcessFailed() {
+    public void When_Handle_WithGpConnectInvalidException_Expect_ProcessFailed() {
         setUpContinueMessage();
         Exception exception = new GpConnectInvalidException(TEST_EXCEPTION_MESSAGE);
         doThrow(exception).when(taskExecutor).execute(any());
@@ -345,7 +345,7 @@ public class TaskHandlerTest {
 
     @Test
     @SneakyThrows
-    public void When_handle_WithGpConnectNotFoundException_Expect_ProcessFailed() {
+    public void When_Handle_WithGpConnectNotFoundException_Expect_ProcessFailed() {
         setUpContinueMessage();
         Exception exception = new GpConnectNotFoundException(TEST_EXCEPTION_MESSAGE);
         doThrow(exception).when(taskExecutor).execute(any());

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandlerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/task/TaskHandlerTest.java
@@ -68,7 +68,7 @@ public class TaskHandlerTest {
     private ProcessFailureHandlingService processFailureHandlingService;
 
     @Mock
-    private ProcessingErrorHandler processingErrorHandler;
+    private TaskErrorHandler taskErrorHandler;
 
     private TaskDefinition taskDefinition;
     private SendAcknowledgementTaskDefinition sendAcknowledgementTaskDefinition;
@@ -97,7 +97,7 @@ public class TaskHandlerTest {
             taskExecutorFactory,
             taskExecutor,
             processFailureHandlingService,
-            processingErrorHandler
+            taskErrorHandler
         );
     }
 
@@ -140,7 +140,7 @@ public class TaskHandlerTest {
         setupAckMessage(SendAcknowledgementTaskDefinition.NACK_TYPE_CODE);
         Exception exception = new RuntimeException(TEST_EXCEPTION_MESSAGE);
         doThrow(exception).when(taskExecutor).execute(any());
-        when(processingErrorHandler.handleProcessingError(eq(exception), any())).thenReturn(false);
+        when(taskErrorHandler.handleProcessingError(eq(exception), any())).thenReturn(false);
 
         var result = taskHandler.handle(message);
 
@@ -159,7 +159,7 @@ public class TaskHandlerTest {
         taskHandler.handle(message);
 
         verify(taskExecutor).execute(taskDefinition);
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     @Test
@@ -169,7 +169,7 @@ public class TaskHandlerTest {
         Exception exception = new RuntimeException(TEST_EXCEPTION_MESSAGE);
         doThrow(exception).when(taskExecutor).execute(any());
 
-        when(processingErrorHandler.handleProcessingError(eq(exception), any()))
+        when(taskErrorHandler.handleProcessingError(eq(exception), any()))
             .thenReturn(true, false);
 
         assertThat(taskHandler.handle(message)).isTrue();
@@ -183,7 +183,7 @@ public class TaskHandlerTest {
         Exception exception = new RuntimeException(TEST_EXCEPTION_MESSAGE);
         doThrow(exception).when(taskExecutor).execute(any());
 
-        when(processingErrorHandler.handleProcessingError(eq(exception), any()))
+        when(taskErrorHandler.handleProcessingError(eq(exception), any()))
             .thenReturn(true, false);
 
         assertThat(taskHandler.handle(message)).isTrue();
@@ -199,7 +199,7 @@ public class TaskHandlerTest {
         doThrow(taskException).when(taskExecutor).execute(any());
 
         var failureHandlingException = new RuntimeException("failure handler exception");
-        doThrow(failureHandlingException).when(processingErrorHandler).handleProcessingError(eq(taskException), any());
+        doThrow(failureHandlingException).when(taskErrorHandler).handleProcessingError(eq(taskException), any());
 
         assertThatThrownBy(
             () -> taskHandler.handle(message)
@@ -242,7 +242,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     @Test
@@ -255,7 +255,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     @Test
@@ -268,7 +268,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
 
@@ -282,7 +282,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     @Test
@@ -295,7 +295,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     @Test
@@ -326,7 +326,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
 
     }
 
@@ -340,7 +340,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     @Test
@@ -353,7 +353,7 @@ public class TaskHandlerTest {
         var result = taskHandler.handle(message);
         assertThat(result).isFalse();
 
-        verify(processingErrorHandler).handleProcessingError(eq(exception), any());
+        verify(taskErrorHandler).handleProcessingError(eq(exception), any());
     }
 
     private void setupAckMessage(String typeCode) throws JMSException {


### PR DESCRIPTION
## Description
The MHS adaptor can limit the amount of external attachments. If the maximum value is hit the outbound service will respond with a http status of 400 and a plain text body describing the validation errors.   

According to the document *20151012_GP2GP 2.2 Spec clarifications.doc *:

>Where a sending system is unable to process an extract due to size of the record it must respond to the EHR_Request with an Application Acknowledgement with Response Code 30.

The adaptor is currently responding with response code 99.