### PR TITLE
NIAD-2480: Bug Fix - diagnostic report filing comments mapping  

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -239,7 +239,7 @@ public class DiagnosticReportMapper {
             .map(Observation::getComment)
             .filter(StringUtils::isNotBlank)
             .map(observationComment -> buildNarrativeStatementForDiagnosticReport(
-                issuedElement, CommentType.AGGREGATE_COMMENT_SET.getCode(), observationComment
+                issuedElement, CommentType.USER_COMMENT.getCode(), observationComment
             ))
             .collect(Collectors.joining(System.lineSeparator()));
 

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-multiple-results.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-multiple-results.xml
@@ -32,7 +32,7 @@ Filing Date: 2020-12-15 15:17:04</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100225154100
 
 (q) - Normal - No Action</text>
@@ -43,7 +43,7 @@ CommentDate:20100225154100
 <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100225154100
 
 (q) - Normal - No Action</text>
@@ -54,7 +54,7 @@ CommentDate:20100225154100
 <component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20100225154100
 
 (q) - Normal - No Action</text>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
@@ -408,7 +408,7 @@
                     <component typeCode="COMP" contextConductionInd="true">
                         <NarrativeStatement classCode="OBS" moodCode="EVN">
                             <id root="394559384658936"/>
-                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                            <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
                                 CommentDate:20100225154100
 
                                 (q) - Normal - No Action
@@ -421,7 +421,7 @@
                     <component typeCode="COMP" contextConductionInd="true">
                         <NarrativeStatement classCode="OBS" moodCode="EVN">
                             <id root="394559384658936"/>
-                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                            <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
                                 CommentDate:20100225154100
 
                                 (q) - Normal - No Action
@@ -434,7 +434,7 @@
                     <component typeCode="COMP" contextConductionInd="true">
                         <NarrativeStatement classCode="OBS" moodCode="EVN">
                             <id root="394559384658936"/>
-                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                            <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
                                 CommentDate:20100225154100
 
                                 (q) - Normal - No Action

--- a/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-observations-inside-report.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-observations-inside-report.xml
@@ -109,7 +109,7 @@ Filing Date: 2010-01-13</text>
 </component><component typeCode="COMP" contextConductionInd="true">
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
 CommentDate:20030221115000
 
 This is some random free text</text>


### PR DESCRIPTION
Map Comment Notes refenced in a diagnostic reports result array to narrative statements with the  EDIFACT comment type `USER COMMENT`.