### PR TITLE
Fix duplicate entries within DocumentReferences array

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
@@ -125,20 +125,7 @@ public class GetGpcStructuredTaskExecutor implements TaskExecutor<GetGpcStructur
             documentsAsExternalAttachments.stream()
                 .filter(documentMetadata -> StringUtils.isBlank(documentMetadata.getUrl()))
                 .peek(absentAttachment -> LOGGER.warn("DocumentReference missing URL: {}", absentAttachment.getDocumentId()))
-                .peek(absentAttachments::add)
-                .map(absentAttachment -> EhrExtractStatus.GpcDocument.builder()
-                    .documentId(absentAttachment.getDocumentId())
-                    .fileName(buildAbsentAttachmentFileName(absentAttachment.getDocumentId()))
-                    .accessDocumentUrl(null)
-                    .objectName(null)
-                    .accessedAt(now)
-                    .taskId(structuredTaskDefinition.getTaskId())
-                    .messageId(structuredTaskDefinition.getConversationId())
-                    .isSkeleton(false)
-                    .identifier(absentAttachment.getIdentifier())
-                    .originalDescription(absentAttachment.getOriginalDescription())
-                    .build())
-                .forEach(ehrStatusGpcDocuments::add);
+                .forEach(absentAttachments::add);
 
             documentsAsExternalAttachments = documentsAsExternalAttachments.stream()
                 .filter(documentMetadata -> StringUtils.isNotBlank(documentMetadata.getUrl()))


### PR DESCRIPTION
When checking for Attachments without a URL, the `GetGpcStructuredTaskExecutor` would insert two entries into the Documents array to be stored within the database.

Adds test to cover this behaviour, and removes duplicate code which generates the additional entry.