### PR TITLE
NIAD-2812: Add document ContentType as provided by GP Connect to SendDocumentTaskDefinition

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.CONVERSATION_ID;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_CONTENT_TYPE;
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_ID;
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_NAME;
 
@@ -90,6 +91,7 @@ public class EhrContinueTest {
         return SendDocumentTaskDefinition.builder()
             .documentName(DOCUMENT_NAME)
             .documentId(DOCUMENT_ID)
+            .documentContentType(DOCUMENT_CONTENT_TYPE)
             .messageId(CONVERSATION_ID)
             .taskId(randomIdGeneratorService.createNewId())
             .conversationId(ehrExtractStatus.getConversationId())

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusTestUtils.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusTestUtils.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.CONVERSATION_ID;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_CONTENT_TYPE;
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_ID;
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_NAME;
 import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.GPC_ACCESS_DOCUMENT_URL;
@@ -72,6 +73,7 @@ public class EhrExtractStatusTestUtils {
                     .messageId(CONVERSATION_ID)
                     .documentId(documentId)
                     .objectName(DOCUMENT_NAME)
+                    .contentType(DOCUMENT_CONTENT_TYPE)
                     .accessDocumentUrl(String.format(GPC_ACCESS_DOCUMENT_URL, documentId))
                     .build()
             )).build();

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrStatusConstants.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrStatusConstants.java
@@ -11,6 +11,7 @@ public class EhrStatusConstants {
     public static final String FROM_ODS_CODE = "GPC001";
     public static final String TO_ODS_CODE = "B82617";
     public static final String DOCUMENT_ID = "07a6483f-732b-461e-86b6-edb665c45510";
+    public static final String DOCUMENT_CONTENT_TYPE = "application/msword";
     public static final String GPC_ACCESS_DOCUMENT_URL = "https://orange.testlab.nhs.uk/B82617/STU3/1/gpconnect/documents/fhir/Binary/%s";
     public static final String MESSAGE_ID = "DFF5321C-C6EA-4AC9-942F-0F6621CC0BFC";
     public static final String DOCUMENT_NAME = "Discharge Summary";

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskDefinition.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskDefinition.java
@@ -24,6 +24,10 @@ public class SendDocumentTaskDefinition extends DocumentTaskDefinition {
      * Position of the document on EhrStatus document list
      */
     private final int documentPosition;
+    /**
+     * Content-Type of the document, as provided by sending system.
+     */
+    private final String documentContentType;
     @Override
     public TaskType getTaskType() {
         return SEND_EHR_CONTINUE;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/request/EhrExtractRequestHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/request/EhrExtractRequestHandler.java
@@ -144,7 +144,8 @@ public class EhrExtractRequestHandler {
                             document.getObjectName(),
                             documentPosition,
                             document.getMessageId(),
-                            document.getDocumentId());
+                            document.getDocumentId(),
+                            document.getContentType());
                     }
                 });
         } else {
@@ -154,11 +155,13 @@ public class EhrExtractRequestHandler {
     }
 
     private void createSendDocumentTasks(
-            EhrExtractStatus ehrExtractStatus, String documentName, int documentLocation, String messageId, String documentId
+            EhrExtractStatus ehrExtractStatus, String documentName, int documentLocation, String messageId,
+            String documentId, String documentContentType
     ) {
         var sendDocumentTaskDefinition = SendDocumentTaskDefinition.builder()
             .documentName(documentName)
             .documentPosition(documentLocation)
+            .documentContentType(documentContentType)
             .taskId(randomIdGeneratorService.createNewId())
             .conversationId(ehrExtractStatus.getConversationId())
             .requestId(ehrExtractStatus.getEhrRequest().getRequestId())

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutorTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutorTest.java
@@ -59,14 +59,14 @@ public class SendDocumentTaskExecutorTest {
 
     @SneakyThrows
     @Test
-    public void When_DocumentNeedsToBeSplitInto5Chunks_Expect_FiveChunksWhereMultipartContentTypeHeaderIsPulledFromStorageDataWrapper() {
+    public void When_DocumentNeedsToBeSplitInto5Chunks_Expect_FiveChunksWhereMultipartContentTypeHeaderIsPulledFromTaskDefinition() {
         final int SIZE_OF_EACH_CHUNK = 1;
         final int NUMBER_OF_CHUNKS = 5;
         final String storageFileName = "large_file_which_will_be_split.txt";
 
         // Arrange
         this.gp2gpConfiguration.setLargeAttachmentThreshold(SIZE_OF_EACH_CHUNK);
-        uploadDocumentToStorageWrapperWithPayloadSize(SIZE_OF_EACH_CHUNK * NUMBER_OF_CHUNKS, storageFileName, "test/example");
+        uploadDocumentToStorageWrapperWithPayloadSize(SIZE_OF_EACH_CHUNK * NUMBER_OF_CHUNKS, storageFileName, "should-not-be-used");
 
         // Act
         this.sendDocumentTaskExecutor.execute(
@@ -75,19 +75,20 @@ public class SendDocumentTaskExecutorTest {
                 .messageId("88")
                 .fromOdsCode("RANDOM-ODS")
                 .conversationId("RANDOM-ID")
+                .documentContentType("should-be-used")
                 .build()
         );
 
         // Assert
         verify(mhsRequestBuilder, times(NUMBER_OF_CHUNKS)).buildSendEhrExtractCommonRequest(
-            argThat(mhsRequestBodyContainsAttachmentWithContentType("test/example")),
+            argThat(mhsRequestBodyContainsAttachmentWithContentType("should-be-used")),
             eq("RANDOM-ID"),
             eq("RANDOM-ODS"),
             any()
         );
 
         verify(mhsRequestBuilder, times(1)).buildSendEhrExtractCommonRequest(
-            argThat(mhsRequestBodyWithAnExternalAttachmentForEachChunkWithContentType(NUMBER_OF_CHUNKS, "test/example")),
+            argThat(mhsRequestBodyWithAnExternalAttachmentForEachChunkWithContentType(NUMBER_OF_CHUNKS, "should-be-used")),
             eq("RANDOM-ID"),
             eq("RANDOM-ODS"),
             any()


### PR DESCRIPTION
This value can then be used as an authoratitive value as opposed to pulling it out of the compiled MHS message.

In follow up work, the MHS message will contain application/octet-stream as this is what Spine requires, but isn't the actual content type which we still need.