### PR TITLE
Create release 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.10] - 2023-08-30
+
+### Added
+
+- Add "/requests" endpoint which returns a history of transfers made. (#500)
+- Support for running the GP2GP adaptor and PS adaptors against single MHS inbound adaptor. (#494)
+
+### Fixed
+
+- GP2GP bug - Patient not found error was returning Response Code "6" instead of "06". (#501)
+- When a GP2GP transfer fails because the MHS Adaptor rejects the attachments, we now return a Response Code of 30
+  previously this situation was unhandled, and defaulted to 99. (#502)
+- Mapping bug - DiagnosticReport result comments were previously generated as a NarrativeStatement with PMIP with 
+  comment type `AGGREGATE COMMENT SET`, they are now generated with `USER COMMENT` (#504).
+- Mapping bug - Lists which referenced [contained elements] were treated as invalid, they should now work (#507).
+- GP2GP bug - Attachments with a content type not supported by Spine were being sent to the MHS Adaptor
+  with their original content type. Now they are sent with `application/octect-stream` to match the GP2GP Spec. (#506)
+
+[contained elements]: https://build.fhir.org/references.html#contained
+
 ## [1.5.7] - 2022-11-25
 
 ### Added

--- a/release/release.sh
+++ b/release/release.sh
@@ -4,17 +4,8 @@ set -e
 
 source ./version.sh
 
-cd ../docker
-docker-compose build gp2gp
+cd ../
 
-docker tag local/gp2gp:latest nhsdev/nia-gp2gp-adaptor:${RELEASE_VERSION}
+docker buildx build -f docker/service/Dockerfile . --platform linux/arm64/v8,linux/amd64 --tag nhsdev/nia-gp2gp-adaptor:${RELEASE_VERSION} --push
 
-docker scan --severity high --file ../docker/service/Dockerfile --exclude-base nhsdev/nia-gp2gp-adaptor:${RELEASE_VERSION}
-
-if [ "$1" == "-y" ];
-then
-  echo "Tagging and pushing Docker image and git tag"
-  docker push nhsdev/nia-gp2gp-adaptor:${RELEASE_VERSION}
-  git tag -a ${RELEASE_VERSION} -m "Release ${RELEASE_VERSION}"
-  git push origin ${RELEASE_VERSION}
-fi
+docker scout cves --only-severity critical,high --ignore-base nhsdev/nia-gp2gp-adaptor:${RELEASE_VERSION}

--- a/release/version.sh
+++ b/release/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-export RELEASE_VERSION=1.5.5
+export RELEASE_VERSION=1.5.10


### PR DESCRIPTION
See commits messages for details.

- [Update release.sh to push a multi-architecture tag](https://github.com/nhsconnect/integration-adaptor-gp2gp/commit/6c07a2d3faf879cb94699417cbfe28f2129b819c)
- [Release version 1.5.10](https://github.com/nhsconnect/integration-adaptor-gp2gp/commit/f0e9122ce26c02d39e3ce56b17066afbdfa39c9c)

TODO: Create a release in GitHub against 4bfec38a68daa793e61066f9a81f5157830ab8d5