### PR TITLE
NIAD-2814: Fixed plain text file attachment being transferred into TPP as Base64Encoded

### DIFF
--- a/docker/wiremock/Dockerfile
+++ b/docker/wiremock/Dockerfile
@@ -1,3 +1,5 @@
-FROM rodolpheche/wiremock
+FROM wiremock/wiremock:2.33.2
 
 COPY stubs /home/wiremock
+
+CMD ["--global-response-templating", "--verbose"]

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,19 +81,19 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649553"
+            "value": "9729649561"
           }
         ],
         "active": true,
         "name": [
           {
             "use": "official",
-            "family": "BOWDEN",
+            "family": "CARMEL",
             "prefix": [
               "MS"
             ],
             "given": [
-              "Flora"
+              "Evelyn"
             ]
           }
         ],
@@ -110,16 +110,16 @@
           }
         ],
         "gender": "female",
-        "birthDate": "2013-06-04",
+        "birthDate": "2012-10-14",
         "address": [
           {
             "use": "home",
             "line": [
-              "1 KINGSWOOD ROAD"
+              "10 VERNON DRIVE"
             ],
             "city": "Manchester",
             "district": "Lancashire",
-            "postalCode": "M25 3AB",
+            "postalCode": "M25 9RA",
             "country": "GBR"
           }
         ],

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -1,0 +1,1209 @@
+{
+  "resourceType": "Bundle",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+    ]
+  },
+  "id": "533e2d13-83d3-4941-b537-c08d33aebb07",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "a3645e72-28d9-11eb-adc1-73609b5ae43f",
+        "meta": {
+          "versionId": "8b27dabf9fff943a9cbbb5c6a1b3ff04",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+            "extension": [
+              {
+                "url": "registrationPeriod",
+                "valuePeriod": {
+                  "start": "1991-04-26"
+                }
+              },
+              {
+                "url": "registrationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-RegistrationType-1",
+                      "code": "R",
+                      "display": "Regular"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSCommunication-1",
+            "extension": [
+              {
+                "url": "language",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-HumanLanguage-1",
+                      "code": "es",
+                      "display": "Spanish; Castilian"
+                    }
+                  ]
+                }
+              },
+              {
+                "url": "interpreterRequired",
+                "valueBoolean": true
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9729649499"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "Fain",
+            "prefix": [
+              "MS"
+            ],
+            "given": [
+              "Jill"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273626410",
+            "use": "mobile"
+          },
+          {
+            "system": "email",
+            "value": "ramon.adam@palmer.info",
+            "use": "work"
+          }
+        ],
+        "gender": "female",
+        "birthDate": "2022-03-22",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "10 Water Lane"
+            ],
+            "city": "Manchester",
+            "district": "Lancashire",
+            "postalCode": "M26 4BS",
+            "country": "GBR"
+          }
+        ],
+        "contact": [
+          {
+            "relationship": [
+              {
+                "text": "parent"
+              }
+            ],
+            "name": {
+              "use": "official",
+              "text": "Ryan Clark"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "+442076849939",
+                "use": "home"
+              },
+              {
+                "system": "phone",
+                "value": "+442038426172",
+                "use": "mobile"
+              },
+              {
+                "system": "email",
+                "value": "ajames@gmail.com",
+                "use": "home"
+              }
+            ],
+            "address": {
+              "use": "home",
+              "line": [
+                "1 Kieran Field"
+              ],
+              "city": "East Heather",
+              "district": "Glamorgan",
+              "postalCode": "L25 8SJ",
+              "country": "GBR"
+            }
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/P83007"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "P83007",
+        "meta": {
+          "versionId": "fa221b0235bec7ad4341a300837af625",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "P83007"
+          }
+        ],
+        "active": true,
+        "name": "Baker's Hill Medical Centre",
+        "address": [
+          {
+            "use": "work",
+            "line": [
+              "101 Yvonne Falls"
+            ],
+            "city": "West Carey",
+            "district": "Norfolk",
+            "postalCode": "MK3 7SA",
+            "country": "GBR"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+441273749184",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "+441455338473",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "bakers.hill@medicus.health",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Problems",
+        "code": {
+          "coding": [
+            {
+              "display": "Problems",
+              "system": "http://snomed.info/sct",
+              "code": "717711000000103"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Allergies and adverse reactions",
+        "code": {
+          "coding": [
+            {
+              "display": "Allergies and adverse reactions",
+              "system": "http://snomed.info/sct",
+              "code": "886921000000105"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Ended allergies",
+        "code": {
+          "coding": [
+            {
+              "display": "Ended allergies",
+              "system": "http://snomed.info/sct",
+              "code": "1103671000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "ms-5e7081bd-28d9-11eb-adc1-f45aed8901cd",
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "ms-5e7081bd-28d9-11eb-adc1-f45aed8901cd"
+          }
+        ],
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                  "code": "prescribed-at-gp-practice",
+                  "display": "Prescribed at GP practice"
+                }
+              ]
+            }
+          },
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+            "valueDateTime": "2022-08-15"
+          }
+        ],
+        "status": "active",
+        "basedOn": [
+          {
+            "reference": "MedicationRequest/mr-5e7081bd-28d9-11eb-adc1-f45aed8901cd"
+          }
+        ],
+        "medicationReference": {
+          "reference": "Medication/52911000001107"
+        },
+        "effectivePeriod": {
+          "start": "2022-08-15"
+        },
+        "dateAsserted": "2022-08-15",
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "taken": "unk",
+        "dosage": [
+          {
+            "text": "1 tablet - every MORNING"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Medication",
+        "id": "52911000001107",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "52911000001107",
+              "display": "Prednisolone 1mg tablets (Alliance Healthcare (Distribution) Ltd)"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "mr-5e7081bd-28d9-11eb-adc1-f45aed8901cd",
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "mr-5e7081bd-28d9-11eb-adc1-f45aed8901cd"
+          }
+        ],
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                  "code": "repeat",
+                  "display": "Repeat"
+                }
+              ]
+            }
+          },
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+            "extension": [
+              {
+                "url": "numberOfRepeatPrescriptionsAllowed",
+                "valueUnsignedInt": 6
+              },
+              {
+                "url": "numberOfRepeatPrescriptionsIssued",
+                "valueUnsignedInt": 1
+              }
+            ]
+          }
+        ],
+        "status": "completed",
+        "intent": "plan",
+        "medicationReference": {
+          "reference": "Medication/52911000001107"
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "authoredOn": "2022-08-15",
+        "recorder": {
+          "reference": "Practitioner/1339aa9b-28d6-11eb-adc1-0242ac120002"
+        },
+        "requester": {
+          "agent": {
+            "reference": "Organization/P83007"
+          }
+        },
+        "dosageInstruction": [
+          {
+            "text": "1 tablet - every MORNING"
+          }
+        ],
+        "dispenseRequest": {
+          "validityPeriod": {
+            "start": "2022-08-15"
+          },
+          "quantity": {
+            "value": 1,
+            "unit": "tablet"
+          },
+          "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "60f7a4d8-28d9-11eb-adc1-fe624adb0198",
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "60f7a4d8-28d9-11eb-adc1-fe624adb0198"
+          }
+        ],
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+              "text": "No information available"
+            }
+          }
+        ],
+        "status": "completed",
+        "basedOn": [
+          {
+            "reference": "MedicationRequest/mr-5e7081bd-28d9-11eb-adc1-f45aed8901cd"
+          }
+        ],
+        "intent": "order",
+        "medicationReference": {
+          "reference": "Medication/52911000001107"
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "authoredOn": "2022-09-06",
+        "recorder": {
+          "reference": "Practitioner/1339aa9b-28d6-11eb-adc1-0242ac120002"
+        },
+        "requester": {
+          "agent": {
+            "reference": "Organization/P83007"
+          }
+        },
+        "dosageInstruction": [
+          {
+            "text": "1 tablet - every MORNING"
+          }
+        ],
+        "dispenseRequest": {
+          "validityPeriod": {
+            "start": "2022-09-06",
+            "end": "2022-10-04"
+          },
+          "quantity": {
+            "value": 1,
+            "unit": "tablet"
+          },
+          "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "1339aa9b-28d6-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "704a92affc89d2a572a13641098a7f5f",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "Davies",
+            "prefix": [
+              "Prof"
+            ],
+            "given": [
+              "Caitlin",
+              "Tina"
+            ],
+            "suffix": [
+              "III"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "8962446c571059058ca90f4e64077c4b",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1"
+          ]
+        },
+        "practitioner": {
+          "reference": "Practitioner/1339aa9b-28d6-11eb-adc1-0242ac120002"
+        },
+        "organization": {
+          "reference": "Organization/P83007"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Medications and medical devices",
+        "code": {
+          "coding": [
+            {
+              "display": "Medications and medical devices",
+              "system": "http://snomed.info/sct",
+              "code": "933361000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "entry": [
+          {
+            "item": {
+              "reference": "MedicationStatement/ms-5e7081bd-28d9-11eb-adc1-f45aed8901cd"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "List of consultations",
+        "code": {
+          "coding": [
+            {
+              "display": "List of consultations",
+              "system": "http://snomed.info/sct",
+              "code": "1149501000000101"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Immunisations",
+        "code": {
+          "coding": [
+            {
+              "display": "Immunisations",
+              "system": "http://snomed.info/sct",
+              "code": "1102181000000102"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "2948a0e6-28d9-11eb-adc1-0f7cb92681ad",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "2948a0e6-28d9-11eb-adc1-0f7cb92681ad"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "248333004",
+              "display": "Standing height",
+              "extension": [
+                {
+                  "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "descriptionId",
+                      "valueId": "370729019"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "effectiveDateTime": "2022-03-22T10:20:00+00:00",
+        "issued": "2022-08-15T18:46:31+01:00",
+        "valueQuantity": {
+          "value": 186,
+          "unit": "cm",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "eb7d4518-28d9-11eb-adc1-c56e09a1f74d",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "eb7d4518-28d9-11eb-adc1-c56e09a1f74d"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "75367002",
+              "display": "Blood pressure",
+              "extension": [
+                {
+                  "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "descriptionId",
+                      "valueId": "125176019"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "effectiveDateTime": "2022-03-22T00:00:00+00:00",
+        "issued": "2022-08-15T18:46:31+01:00",
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368208006",
+              "display": "Left upper arm structure",
+              "extension": [
+                {
+                  "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "descriptionId",
+                      "valueId": "507686016"
+                    },
+                    {
+                      "url": "descriptionDisplay",
+                      "valueString": "Left arm"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "271649006",
+                  "display": "Systolic blood pressure",
+                  "extension": [
+                    {
+                      "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "406507015"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 184,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "271650006",
+                  "display": "Diastolic blood pressure",
+                  "extension": [
+                    {
+                      "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                      "extension": [
+                        {
+                          "url": "descriptionId",
+                          "valueId": "406508013"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 85,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Uncategorised data",
+        "code": {
+          "coding": [
+            {
+              "display": "Miscellaneous records",
+              "system": "http://snomed.info/sct",
+              "code": "826501000000100"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "entry": [
+          {
+            "item": {
+              "reference": "Observation/2948a0e6-28d9-11eb-adc1-0f7cb92681ad"
+            }
+          },
+          {
+            "item": {
+              "reference": "Observation/eb7d4518-28d9-11eb-adc1-c56e09a1f74d"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Investigations and results",
+        "code": {
+          "coding": [
+            {
+              "display": "Investigations and results",
+              "system": "http://snomed.info/sct",
+              "code": "887191000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Outbound referral",
+        "code": {
+          "coding": [
+            {
+              "display": "Outbound referral",
+              "system": "http://snomed.info/sct",
+              "code": "792931000000107"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "List",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "title": "Patient recall administration",
+        "code": {
+          "coding": [
+            {
+              "display": "Patient recall administration",
+              "system": "http://snomed.info/sct",
+              "code": "714311000000108"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "note": [
+          {
+            "text": "Information not available."
+          }
+        ],
+        "emptyReason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-ListEmptyReasonCode-1",
+              "code": "no-content-recorded",
+              "display": "No Content Recorded"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "DocumentReference",
+        "id": "care-record-document--1ba35a9d-a97d-425d-88b4-dddfc823bff5",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+          ]
+        },
+        "masterIdentifier": {
+          "system": "https://medicus.health",
+          "value": "care-record-document--1ba35a9d-a97d-425d-88b4-dddfc823bff5"
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "care-record-document--1ba35a9d-a97d-425d-88b4-dddfc823bff5"
+          }
+        ],
+        "status": "current",
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "715861000000104",
+              "display": "Test result",
+              "extension": [
+                {
+                  "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "descriptionId",
+                      "valueId": "1568421000000118"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "created": "1988-04-23",
+        "indexed": "2022-08-15T18:35:52+01:00",
+        "author": [
+          {
+            "reference": "Practitioner/1332aa7c-28d6-11eb-adc1-0242ac120002"
+          }
+        ],
+        "custodian": {
+          "reference": "Organization/P83007"
+        },
+        "description": "Test result",
+        "content": [
+          {
+            "attachment": {
+              "contentType": "application/octet-stream",
+              "size": 7206508,
+              "url": "{{request.baseUrl}}/P83007/STU3/1/gpconnect/documents/fhir/Binary/care-record-document--1ba35a9d-a97d-425d-88b4-dddfc823bff5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "1332aa7c-28d6-11eb-adc1-0242ac120002",
+        "meta": {
+          "versionId": "79d7a0c985c4eac313c97b3f91e402fa",
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+          ]
+        },
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "text": "Jason Parker"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "2490570d973fd416d117823a5fd52aff",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1"
+          ]
+        },
+        "practitioner": {
+          "reference": "Practitioner/1332aa7c-28d6-11eb-adc1-0242ac120002"
+        },
+        "organization": {
+          "reference": "Organization/P83007"
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "DocumentReference",
+        "id": "care-record-document--30e49be4-42aa-4dff-87d0-3c1c2cc22a6f",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+          ]
+        },
+        "masterIdentifier": {
+          "system": "https://medicus.health",
+          "value": "care-record-document--30e49be4-42aa-4dff-87d0-3c1c2cc22a6f"
+        },
+        "identifier": [
+          {
+            "system": "https://medicus.health",
+            "value": "care-record-document--30e49be4-42aa-4dff-87d0-3c1c2cc22a6f"
+          }
+        ],
+        "status": "current",
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "715861000000104",
+              "display": "Test result",
+              "extension": [
+                {
+                  "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension": [
+                    {
+                      "url": "1568421000000118",
+                      "valueId": "2143901000000113"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/a3645e72-28d9-11eb-adc1-73609b5ae43f"
+        },
+        "created": "1992-03-04",
+        "indexed": "2022-08-15T18:35:53+01:00",
+        "author": [
+          {
+            "reference": "Practitioner/1332aa7c-28d6-11eb-adc1-0242ac120002"
+          }
+        ],
+        "custodian": {
+          "reference": "Organization/P83007"
+        },
+        "description": "Test result",
+        "content": [
+          {
+            "attachment": {
+              "contentType": "text/plain",
+              "size": 12412,
+              "url": "{{request.baseUrl}}/P83007/STU3/1/gpconnect/documents/fhir/Binary/care-record-document--30e49be4-42aa-4dff-87d0-3c1c2cc22a6f"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,19 +81,19 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649499"
+            "value": "9729649502"
           }
         ],
         "active": true,
         "name": [
           {
             "use": "official",
-            "family": "Fain",
+            "family": "Greir",
             "prefix": [
               "MS"
             ],
             "given": [
-              "Jill"
+              "Alfred"
             ]
           }
         ],

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,19 +81,19 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649502"
+            "value": "9729649510"
           }
         ],
         "active": true,
         "name": [
           {
             "use": "official",
-            "family": "Greir",
+            "family": "Kereva",
             "prefix": [
               "MS"
             ],
             "given": [
-              "Alfred"
+              "Joel"
             ]
           }
         ],
@@ -109,8 +109,8 @@
             "use": "work"
           }
         ],
-        "gender": "female",
-        "birthDate": "2022-03-22",
+        "gender": "male",
+        "birthDate": "1995-11-22",
         "address": [
           {
             "use": "home",

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,19 +81,19 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649561"
+            "value": "9729649588"
           }
         ],
         "active": true,
         "name": [
           {
             "use": "official",
-            "family": "CARMEL",
+            "family": "SUDLOW",
             "prefix": [
-              "MS"
+              "MR"
             ],
             "given": [
-              "Evelyn"
+              "Calvin"
             ]
           }
         ],
@@ -109,17 +109,17 @@
             "use": "work"
           }
         ],
-        "gender": "female",
-        "birthDate": "2012-10-14",
+        "gender": "male",
+        "birthDate": "1985-02-13",
         "address": [
           {
             "use": "home",
             "line": [
-              "10 VERNON DRIVE"
+              "68 EAST STREET"
             ],
-            "city": "Manchester",
+            "city": "BURY",
             "district": "Lancashire",
-            "postalCode": "M25 9RA",
+            "postalCode": "BL9 0RU",
             "country": "GBR"
           }
         ],

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,19 +81,19 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649529"
+            "value": "9729649537"
           }
         ],
         "active": true,
         "name": [
           {
             "use": "official",
-            "family": "Kereva",
+            "family": "POLAND",
             "prefix": [
               "MS"
             ],
             "given": [
-              "Louisa"
+              "Claire"
             ]
           }
         ],
@@ -109,17 +109,17 @@
             "use": "work"
           }
         ],
-        "gender": "male",
-        "birthDate": "2012-04-21",
+        "gender": "female",
+        "birthDate": "2009-07-15",
         "address": [
           {
             "use": "home",
             "line": [
-              "10 Water Lane"
+              "4 EAST AVENUE"
             ],
             "city": "Manchester",
             "district": "Lancashire",
-            "postalCode": "M26 4BS",
+            "postalCode": "M45 7JD",
             "country": "GBR"
           }
         ],

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,7 +81,7 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649537"
+            "value": "9729649545"
           }
         ],
         "active": true,
@@ -90,10 +90,10 @@
             "use": "official",
             "family": "POLAND",
             "prefix": [
-              "MS"
+              "MR"
             ],
             "given": [
-              "Claire"
+              "Harley"
             ]
           }
         ],
@@ -109,8 +109,8 @@
             "use": "work"
           }
         ],
-        "gender": "female",
-        "birthDate": "2009-07-15",
+        "gender": "male",
+        "birthDate": "2023-08-20",
         "address": [
           {
             "use": "home",

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,19 +81,19 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649545"
+            "value": "9729649553"
           }
         ],
         "active": true,
         "name": [
           {
             "use": "official",
-            "family": "POLAND",
+            "family": "BOWDEN",
             "prefix": [
-              "MR"
+              "MS"
             ],
             "given": [
-              "Harley"
+              "Flora"
             ]
           }
         ],
@@ -109,17 +109,17 @@
             "use": "work"
           }
         ],
-        "gender": "male",
-        "birthDate": "2023-08-20",
+        "gender": "female",
+        "birthDate": "2013-06-04",
         "address": [
           {
             "use": "home",
             "line": [
-              "4 EAST AVENUE"
+              "1 KINGSWOOD ROAD"
             ],
             "city": "Manchester",
             "district": "Lancashire",
-            "postalCode": "M45 7JD",
+            "postalCode": "M25 3AB",
             "country": "GBR"
           }
         ],

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,7 +81,7 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649510"
+            "value": "9729649529"
           }
         ],
         "active": true,
@@ -93,7 +93,7 @@
               "MS"
             ],
             "given": [
-              "Joel"
+              "Louisa"
             ]
           }
         ],
@@ -110,7 +110,7 @@
           }
         ],
         "gender": "male",
-        "birthDate": "1995-11-22",
+        "birthDate": "2012-04-21",
         "address": [
           {
             "use": "home",

--- a/docker/wiremock/stubs/__files/correctSimpleTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctSimpleTextDocAttachment.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Binary",
+  "id": "care-record-document--30e49be4-42aa-4dff-87d0-3c1c2cc22a6f",
+  "contentType": "text/plain",
+  "content": "SG93IGFyIHlvdQ=="
+}

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649561')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649588')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -1,0 +1,27 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "urlPattern": "\/.*\/STU3\/1\/gpconnect\/fhir\/Patient\/[$]gpc[.]migratestructuredrecord",
+    "bodyPatterns" : [ {
+      "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
+    },
+      {
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649499')]"
+      }]
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "correctPatientStructuredRecordWithTextDocAttachment.json",
+    "headers": {
+      "Server": "nginx",
+      "Date": "{{now format='E, d MMM y HH:mm:ss z'}}",
+      "Content-Type": "application/fhir+json;charset=UTF-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-store",
+      "X-Powered-By": "HAPI FHIR 3.0.0 REST Server (FHIR Server; FHIR 3.0.1/DSTU3)",
+      "Strict-Transport-Security":"max-age=31536000"
+    }
+  }
+}

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649537')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649545')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649553')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649561')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649510')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649529')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649499')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649502')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649502')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649510')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649529')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649537')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveCorrectPatientStructuredRecordWithSimpleDocAttachment.json
@@ -7,7 +7,7 @@
       "matchesJsonPath" : "$.parameter[?(@.name == 'patientNHSNumber')]"
     },
       {
-        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649545')]"
+        "matchesJsonPath" : "$.parameter[0].valueIdentifier[?(@.value == '9729649553')]"
       }]
   },
   "response": {

--- a/docker/wiremock/stubs/mappings/retrieveSimpleTextDocAttachment.json
+++ b/docker/wiremock/stubs/mappings/retrieveSimpleTextDocAttachment.json
@@ -1,0 +1,21 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPattern": "\/.*\/STU3\/1\/gpconnect\/documents\/fhir\/Binary\/care-record-document--30e49be4-42aa-4dff-87d0-3c1c2cc22a6f"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "correctSimpleTextDocAttachment.json",
+    "headers": {
+      "Server":"nginx",
+      "Date":"Tue, 12 Jan 2021 11:36:57 GMT",
+      "Content-Type":"application/fhir+json;charset=UTF-8",
+      "Connection":"keep-alive",
+      "expires":"0",
+      "Cache-Control": "no-store",
+      "Pragma": "no-cache",
+      "Strict-Transport-Security": "max-age:31536000"
+    }
+  }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutor.java
@@ -85,7 +85,7 @@ public class SendDocumentTaskExecutor implements TaskExecutor<SendDocumentTaskDe
                         .contentType(taskDefinition.getDocumentContentType())
                         .compressed(false) //const
                         .largeAttachment(false) // const - chunks are not large attachments themself
-                        .originalBase64(true) //const
+                        .originalBase64(false) //const
                         .build()
                         .toString())
                     .messageId(messageId)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/SendDocumentTaskExecutor.java
@@ -85,7 +85,7 @@ public class SendDocumentTaskExecutor implements TaskExecutor<SendDocumentTaskDe
                         .contentType(taskDefinition.getDocumentContentType())
                         .compressed(false) //const
                         .largeAttachment(false) // const - chunks are not large attachments themself
-                        .originalBase64(false) //const
+                        .originalBase64(true) //const
                         .build()
                         .toString())
                     .messageId(messageId)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
@@ -78,7 +78,7 @@ public class StructuredRecordMappingService {
                 .contentType(contentType)
                 .compressed(false) // always false for GPC documents
                 .largeAttachment(isLargeAttachment(attachment))
-                .originalBase64(false) // always true
+                .originalBase64(false)
                 .documentId(documentId)
                 .build()
                 .toString()

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
@@ -78,7 +78,7 @@ public class StructuredRecordMappingService {
                 .contentType(contentType)
                 .compressed(false) // always false for GPC documents
                 .largeAttachment(isLargeAttachment(attachment))
-                .originalBase64(true) // always true
+                .originalBase64(false) // always true
                 .documentId(documentId)
                 .build()
                 .toString()

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingServiceTest.java
@@ -64,7 +64,7 @@ class StructuredRecordMappingServiceTest {
         "111_new_doc_manifest_id.txt", "text/plain", List.of(),
         buildAttachmentDescription(
             "111_new_doc_manifest_id.txt", "text/plain", false,
-            false, true, NEW_DOC_MANIFEST_ID_1
+            false, false, NEW_DOC_MANIFEST_ID_1
         )
     );
     private static final OutboundMessage.ExternalAttachment EXPECTED_ATTACHMENT_PRESENT_2 = buildExternalAttachment(
@@ -72,7 +72,7 @@ class StructuredRecordMappingServiceTest {
         "222_new_doc_manifest_id.html", "text/html", List.of(),
         buildAttachmentDescription(
             "222_new_doc_manifest_id.html", "text/html", false,
-            false, true, NEW_DOC_MANIFEST_ID_2
+            false, false, NEW_DOC_MANIFEST_ID_2
         )
     );
     private static final OutboundMessage.ExternalAttachment EXPECTED_ATTACHMENT_ABSENT_1 = buildExternalAttachment(
@@ -80,7 +80,7 @@ class StructuredRecordMappingServiceTest {
         "AbsentAttachment111_new_doc_manifest_id.txt", "text/plain", List.of(),
         buildAttachmentDescription(
             "AbsentAttachment111_new_doc_manifest_id.txt", "text/plain", false,
-            false, true, NEW_DOC_MANIFEST_ID_1
+            false, false, NEW_DOC_MANIFEST_ID_1
         )
     );
     private static final OutboundMessage.ExternalAttachment EXPECTED_ATTACHMENT_ABSENT_2 = buildExternalAttachment(
@@ -88,7 +88,7 @@ class StructuredRecordMappingServiceTest {
         "AbsentAttachment111_new_doc_manifest_id.txt", "text/plain", List.of(),
         buildAttachmentDescription(
             "AbsentAttachment111_new_doc_manifest_id.txt", "text/plain", false,
-            false, true, NEW_DOC_MANIFEST_ID_1
+            false, false, NEW_DOC_MANIFEST_ID_1
         )
     );
 


### PR DESCRIPTION
## What

In the structured record mapping service, we have changed the outbound message which was always being created with a hardcoded value for `originalBase64` as `true`.  This flag appears to be ignored by EMIS, however it affected the import into TPP.

The following changes have been made:

* `originalBase64` will now be hardcoded to `false` when creating the outbound message in the structured record mapping service
* Unit Tests have been updated to reflect this change
* WireMock updated to assist in testing, with new responses created for this

## Why

When transferring a plain text file to TPP the text attachment was stored with the content encoded as Base64 even though the original attachment was not encoded.   In EMIS this attachment is displayed in plain text as expected.  This is not correct behaviour and this could cause confusion when the attachment is viewed.

This was reported in [NIAD-2814](https://gpitbjss.atlassian.net/browse/NIAD-2814)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes