### PR TITLE
Add PR template to aid with code review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What
+
+Please include a summary of the changes and the related issue
+
+## Why
+
+Please include details of the reasoning for these changes
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+
+- [ ] I have performed a self-review of my code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users


### PR DESCRIPTION
## What

This adds a pull request template to be provided when a new pull request is opened

## Why

To ensure that pull requests are created with sufficient detail and to confirm that that required self checks have been completed

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
