### PR TITLE
Add 1hr timeout to pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
     options {
         timestamps()
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        timeout(time: 1, unit: 'HOURS')
     }
 
     environment {


### PR DESCRIPTION
## What

Add 1hr timeout to pipeline

## Why

Pipeline currently has no timeout, which means that a technical fault can result in it needing to be manually cancelled.

A 1hr limit also ensures that we don't create a really slow pipeline, arguably 1hr is too long as well.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
