### PR TITLE
guard against null pointer in JMS error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Guard against possible null pointer error in exception handler.
+
 ## [1.5.11] - 2023-09-26
 
 ### Fixed

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/amqp/JmsListenerErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/amqp/JmsListenerErrorHandler.java
@@ -18,12 +18,27 @@ public class JmsListenerErrorHandler implements ErrorHandler {
         MhsConnectionException.class, "Unable to connect to MHS Outbound"
     );
 
+    /**
+     * Increment the delivery count for all exceptions, except for RETRYABLE_EXCEPTION_MESSAGES which are retried indefinitely.
+     * See <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jms/listener/AbstractMessageListenerContainer.html#class-description">AbstractMessageListenerContainer</a>
+     * for documentation.
+     */
     @Override
     public void handleError(Throwable t) {
 
-        Throwable cause = t.getCause();
-        LOGGER.warn("Caught Error cause of type: [{}], with message: [{}]", cause.getClass().toString(), cause.getMessage());
+        LOGGER.error("Handling JMS message error due to [{}] with message [{}]", t.getClass(), t.getMessage());
+        t.printStackTrace();
 
+        Throwable cause = t.getCause();
+        if (cause == null) {
+            return;
+        }
+
+        Class<? extends Throwable> classOfCause = cause.getClass();
+        LOGGER.error("Caught Error cause of type: [{}], with message: [{}]", classOfCause.toString(), cause.getMessage());
+
+        // Retry these specific exceptions continuously until they stop happening.
+        // These retries will happen until the associated transfer times out.
         if (RETRYABLE_EXCEPTION_MESSAGES.containsKey(cause.getClass())) {
             throw new RuntimeException(RETRYABLE_EXCEPTION_MESSAGES.get(cause.getClass()));
         }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/amqp/JmsListenerErrorHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/amqp/JmsListenerErrorHandler.java
@@ -34,8 +34,7 @@ public class JmsListenerErrorHandler implements ErrorHandler {
             return;
         }
 
-        Class<? extends Throwable> classOfCause = cause.getClass();
-        LOGGER.error("Caught Error cause of type: [{}], with message: [{}]", classOfCause.toString(), cause.getMessage());
+        LOGGER.error("Caught Error cause of type: [{}], with message: [{}]", cause.getClass().toString(), cause.getMessage());
 
         // Retry these specific exceptions continuously until they stop happening.
         // These retries will happen until the associated transfer times out.


### PR DESCRIPTION
## What

Guard against null pointer in JMS Error Handler.

## Why

A null pointer was encountered during testing of the PS Adaptor. This change introduces the prevention, as the implementation of the handler is the same for the GP2GP Adaptor.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
