### PR TITLE
Update packages for TestContainers / MongoDb

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation "org.assertj:assertj-core:3.18.1"
-	testImplementation ("org.testcontainers:testcontainers:1.15.1") {
+	testImplementation ("org.testcontainers:testcontainers:1.16.3") {
 		exclude group: 'org.apache.commons', module: 'commons-compress'
 	}
 	testImplementation 'org.awaitility:awaitility:4.0.3'

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/testcontainers/MongoDbContainer.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/testcontainers/MongoDbContainer.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class MongoDbContainer extends GenericContainer<MongoDbContainer> {
     public static final int MONGODB_PORT = 27017;
-    public static final String DEFAULT_IMAGE_AND_TAG = "mongo:3.4.4";
+    public static final String DEFAULT_IMAGE_AND_TAG = "mongo:3.6.23";
     private static MongoDbContainer container;
 
     private MongoDbContainer() {


### PR DESCRIPTION
## What

Update TestContainers version to testcontainers:1.16.3
Update MongoDb version for test containers to mongo:3.6.23

## Why

Due to issues building and running integration tests on Apple M1 processor it has been required to update the test containers and MongoDb databases.

[Testcontainers for java 1.6.0 release information](https://github.com/testcontainers/testcontainers-java/releases/tag/1.16.0)

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
