### PR TITLE
NIAD-2944: Add utility method to get in-progress transfers

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -1,0 +1,324 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.ACK_TYPE;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.FROM_ASID;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.FROM_ODS_CODE;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.FROM_PARTY_ID;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.INCUMBENT_NACK_CODE;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.INCUMBENT_NACK_DISPLAY;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.NHS_NUMBER;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.NME_NACK_CODE;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.NME_NACK_DISPLAY;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.NME_NACK_TYPE;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.TO_ASID;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.TO_ODS_CODE;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
+
+@ExtendWith({MongoDBExtension.class})
+@DirtiesContext
+@SpringBootTest
+public class EhrExtractStatusServiceTest {
+
+    private static final Instant FIVE_DAYS_AGO = Instant.now().minus(Duration.ofDays(5));
+
+    @Autowired
+    private EhrExtractStatusService ehrExtractStatusService;
+
+    @Autowired
+    private EhrExtractStatusRepository ehrExtractStatusRepository;
+
+    @BeforeEach
+    public void emptyDatabase() {
+        ehrExtractStatusRepository.deleteAll();
+    }
+
+    @Test
+    public void When_FindInProgressTransfers_With_OneInProgress_Expect_Returned() {
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        addInProgressTransfer(inProgressConversationId);
+
+        List<EhrExtractStatus> results = ehrExtractStatusService.findInProgressTransfers();
+
+        assertThat(results.size()).isOne();
+        assertThat(results.get(0).getConversationId()).isEqualTo(inProgressConversationId);
+    }
+
+    @Test
+    public void When_FindInProgressTransfers_With_MixedTransfers_Expect_InProgressFound() {
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        addInProgressTransfer(inProgressConversationId);
+        addCompleteTransfer();
+        addFailedIncumbentTransfer();
+        addFailedNmeTransfer();
+
+        List<EhrExtractStatus> results = ehrExtractStatusService.findInProgressTransfers();
+
+        assertThat(results.size()).isOne();
+
+        assertThat(results.get(0).getConversationId()).isEqualTo(inProgressConversationId);
+    }
+
+    @Test
+    public void When_FindInProgressTransfers_With_AllFailedOrComplete_Expect_EmptyList() {
+        addCompleteTransfer();
+        addCompleteTransfer();
+        addFailedIncumbentTransfer();
+        addFailedNmeTransfer();
+        addFailedIncumbentTransfer();
+
+        List<EhrExtractStatus> results = ehrExtractStatusService.findInProgressTransfers();
+
+        assertThat(results.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void When_FindInProgressTransfers_With_MultipleInProgress_Expect_AllReturned() {
+        var inProgressConversationIds = List.of(
+            generateRandomUppercaseUUID(),
+            generateRandomUppercaseUUID(),
+            generateRandomUppercaseUUID()
+        );
+
+        addFailedIncumbentTransfer();
+
+        for (String inProgressConversationId : inProgressConversationIds) {
+            addInProgressTransfer(inProgressConversationId);
+        }
+
+        List<EhrExtractStatus> results = ehrExtractStatusService.findInProgressTransfers();
+
+        assertThat(results.size()).isEqualTo(inProgressConversationIds.size());
+
+        var returnedConversationIds = results.stream()
+            .map(EhrExtractStatus::getConversationId)
+            .collect(Collectors.toList());
+
+        assertThat(returnedConversationIds).isEqualTo(inProgressConversationIds);
+    }
+
+    private void addInProgressTransfer(String conversationId) {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(conversationId)
+            .created(FIVE_DAYS_AGO)
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                .documents(new ArrayList<>())
+                .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                .accessedAt(FIVE_DAYS_AGO)
+                .objectName(generateRandomUppercaseUUID() + ".json")
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .messageTimestamp(FIVE_DAYS_AGO)
+            .updatedAt(FIVE_DAYS_AGO)
+            .build();
+
+        ehrExtractStatusRepository.save(extractStatus);
+    }
+
+    private void addFailedNmeTransfer() {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(EhrExtractStatus.AckPending.builder()
+                .messageId(generateRandomUppercaseUUID())
+                .taskId(generateRandomUppercaseUUID())
+                .typeCode(NME_NACK_TYPE)
+                .updatedAt(FIVE_DAYS_AGO.toString())
+                .build())
+            .ackToRequester(EhrExtractStatus.AckToRequester.builder()
+                .detail(NME_NACK_DISPLAY)
+                .messageId(generateRandomUppercaseUUID())
+                .reasonCode(NME_NACK_CODE)
+                .taskId(generateRandomUppercaseUUID())
+                .typeCode(NME_NACK_TYPE)
+                .build())
+            .conversationId(generateRandomUppercaseUUID())
+            .created(FIVE_DAYS_AGO)
+            .ehrRequest(buildEhrRequest())
+            .error(EhrExtractStatus.Error.builder()
+                .code(NME_NACK_CODE)
+                .message(NME_NACK_DISPLAY)
+                .occurredAt(FIVE_DAYS_AGO)
+                .taskType("GET_GPC_STRUCTURED")
+                .build())
+            .updatedAt(FIVE_DAYS_AGO)
+            .build();
+
+        ehrExtractStatusRepository.save(extractStatus);
+    }
+
+    private void addFailedIncumbentTransfer() {
+        String ehrMessageRef = generateRandomUppercaseUUID();
+
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackHistory(EhrExtractStatus.AckHistory.builder()
+                .acks(List.of(
+                    EhrExtractStatus.EhrReceivedAcknowledgement.builder()
+                        .rootId(generateRandomUppercaseUUID())
+                        .received(FIVE_DAYS_AGO)
+                        .conversationClosed(FIVE_DAYS_AGO)
+                        .errors(List.of(
+                            EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails.builder()
+                                .code(INCUMBENT_NACK_CODE)
+                                .display(INCUMBENT_NACK_DISPLAY)
+                                .build()))
+                        .messageRef(ehrMessageRef)
+                        .build()))
+                .build())
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(generateRandomUppercaseUUID())
+            .created(FIVE_DAYS_AGO)
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder()
+                .conversationClosed(FIVE_DAYS_AGO)
+                .errors(List.of(
+                    EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails.builder()
+                        .code(INCUMBENT_NACK_CODE)
+                        .display(INCUMBENT_NACK_DISPLAY)
+                        .build()))
+                .messageRef(ehrMessageRef)
+                .received(FIVE_DAYS_AGO)
+                .rootId(generateRandomUppercaseUUID())
+                .build())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                .documents(new ArrayList<>())
+                .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                .accessedAt(FIVE_DAYS_AGO)
+                .objectName(generateRandomUppercaseUUID() + ".json")
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .messageTimestamp(FIVE_DAYS_AGO)
+            .updatedAt(FIVE_DAYS_AGO)
+            .build();
+
+        ehrExtractStatusRepository.save(extractStatus);
+    }
+
+    public void addCompleteTransfer() {
+        String ehrMessageRef = generateRandomUppercaseUUID();
+
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackHistory(EhrExtractStatus.AckHistory.builder()
+                .acks(List.of(
+                    EhrExtractStatus.EhrReceivedAcknowledgement.builder()
+                        .rootId(generateRandomUppercaseUUID())
+                        .received(FIVE_DAYS_AGO)
+                        .conversationClosed(FIVE_DAYS_AGO)
+                        .messageRef(ehrMessageRef)
+                        .build()))
+                .build())
+            .ackPending(EhrExtractStatus.AckPending.builder()
+                .messageId(generateRandomUppercaseUUID())
+                .taskId(generateRandomUppercaseUUID())
+                .typeCode(ACK_TYPE)
+                .updatedAt(FIVE_DAYS_AGO.toString())
+                .build())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(generateRandomUppercaseUUID())
+            .created(FIVE_DAYS_AGO)
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder()
+                .conversationClosed(FIVE_DAYS_AGO)
+                .messageRef(ehrMessageRef)
+                .received(FIVE_DAYS_AGO)
+                .rootId(generateRandomUppercaseUUID())
+                .build())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                .documents(new ArrayList<>())
+                .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                .accessedAt(FIVE_DAYS_AGO)
+                .objectName(generateRandomUppercaseUUID() + ".json")
+                .taskId(generateRandomUppercaseUUID())
+                .build())
+            .messageTimestamp(FIVE_DAYS_AGO)
+            .updatedAt(FIVE_DAYS_AGO)
+            .build();
+
+        ehrExtractStatusRepository.save(extractStatus);
+
+    }
+
+    private String generateRandomUppercaseUUID() {
+        return UUID.randomUUID().toString().toUpperCase();
+    }
+
+    private EhrExtractStatus.AckPending buildPositiveAckPending() {
+        return EhrExtractStatus.AckPending.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .updatedAt(FIVE_DAYS_AGO.toString())
+            .build();
+    }
+
+    private EhrExtractStatus.AckToRequester buildPositiveAckToRequester() {
+        return EhrExtractStatus.AckToRequester.builder()
+            .detail(null)
+            .messageId(generateRandomUppercaseUUID())
+            .reasonCode(null)
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .build();
+    }
+
+    private EhrExtractStatus.EhrRequest buildEhrRequest() {
+        return EhrExtractStatus.EhrRequest.builder()
+            .requestId(generateRandomUppercaseUUID())
+            .nhsNumber(NHS_NUMBER)
+            .fromPartyId(FROM_PARTY_ID)
+            .fromAsid(FROM_ASID)
+            .toAsid(TO_ASID)
+            .toOdsCode(TO_ODS_CODE)
+            .fromOdsCode(FROM_ODS_CODE)
+            .messageId(generateRandomUppercaseUUID())
+            .build();
+    }
+}

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrStatusConstants.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrStatusConstants.java
@@ -15,4 +15,11 @@ public class EhrStatusConstants {
     public static final String GPC_ACCESS_DOCUMENT_URL = "https://orange.testlab.nhs.uk/B82617/STU3/1/gpconnect/documents/fhir/Binary/%s";
     public static final String MESSAGE_ID = "DFF5321C-C6EA-4AC9-942F-0F6621CC0BFC";
     public static final String DOCUMENT_NAME = "Discharge Summary";
+
+    public static final String NME_NACK_CODE = "06";
+    public static final String NME_NACK_DISPLAY = "Patient not at surgery.";
+    public static final String NME_NACK_TYPE = "AE";
+    public static final String INCUMBENT_NACK_CODE = "99";
+    public static final String INCUMBENT_NACK_DISPLAY = "Unexpected condition.";
+    public static final String ACK_TYPE = "AA";
 }


### PR DESCRIPTION
## What

As a subtask of NIAD-2290 (sender timeout) add a utility method to get in-progress transfers. 

## Why

The 8 day timeout only needs to check in-progress transfers. we do not currently have a method for this in the EhrExtractStatusService. 

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
