### PR TITLE
Upgrade from jdk-11.0.11+9 to jdk-11.0.21+9

### DIFF
--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -10,7 +10,7 @@ FROM build AS package
 
 RUN gradle --build-cache bootJar
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11-jre-focal
 
 EXPOSE 8080
 


### PR DESCRIPTION
## What

The focal image appears to be a suitable replacement as it is also based on Ubuntu 20.04

## Why

The adoptopenjdk images have been deprecated since 2021-08-01 in favour of eclipse-temurin.

This should bring in the latest security fixes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
