### PR TITLE
NIAD-2929

### DIFF
--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -338,7 +338,7 @@ public class EhrExtractTest {
             "ContentType=text/xml",
             "Compressed=Yes",
             "LargeAttachment=No",
-            "OriginalBase64=Yes",
+            "OriginalBase64=No",
             "Length=",
             "DomainData=\"X-GP2GP-Skeleton: Yes\"");
 

--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -340,7 +340,7 @@ public class EhrExtractTest {
             "LargeAttachment=No",
             "OriginalBase64=Yes",
             "Length=",
-            "DomainData=X-GP2GP-Skeleton: Yes");
+            "DomainData=\"X-GP2GP-Skeleton: Yes\"");
 
         var documentReferenceXPath = String
             .format(DOCUMENT_REFERENCE_XPATH_TEMPLATE, documentId)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
@@ -287,7 +287,7 @@ public class GetGpcStructuredTaskExecutor implements TaskExecutor<GetGpcStructur
                 .length(compressedAndEncodedEhrExtractSize)
                 .compressed(true)
                 .largeAttachment(compressedAndEncodedEhrExtractSize > gp2gpConfiguration.getLargeAttachmentThreshold())
-                .originalBase64(true) // always true for compressed base64-encoded large ehr extract
+                .originalBase64(false)
                 .domainData(SKELETON_ATTACHMENT)
                 .build()
                 .toString())

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/model/OutboundMessage.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/model/OutboundMessage.java
@@ -110,7 +110,7 @@ public class OutboundMessage {
                         Optional.ofNullable(documentId)
                         .map(docId -> "Length=${" + LENGTH_PLACEHOLDER + docId + "}")
                         .orElse(StringUtils.EMPTY)),
-                Optional.ofNullable(domainData).map(value -> "DomainData=" + value).orElse(StringUtils.EMPTY));
+                Optional.ofNullable(domainData).map(value -> "DomainData=\"" + value + "\"").orElse(StringUtils.EMPTY));
             // all this below to pretty indent on MHS side
             return descriptionElements
                 .filter(StringUtils::isNotBlank)

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/mhs/model/AttachmentDescriptionTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/mhs/model/AttachmentDescriptionTest.java
@@ -45,6 +45,6 @@ class AttachmentDescriptionTest {
             + "ContentType=some_other_content_type "
             + "Compressed=Yes LargeAttachment=Yes "
             + "OriginalBase64=Yes Length=123 "
-            + "DomainData=some_other_domain_data");
+            + "DomainData=\"some_other_domain_data\"");
     }
 }


### PR DESCRIPTION
## What

1. Wrap DomainData in quote marks as per the LargeMessage spec
2. Set OriginalBase64 to No for a Skeleton message

## Why

### DomainData

See LM24 of the Large Message spec:
> DomainData shall only be included when the HL7 is itself
> larger than Spine maximum message size (LM01 D).
> In this case the entry will be DomainData=”X-GP2GP-Skeleton: Yes”.

### OriginalBase64

This value according to the GP2GP spec is:
> The CCLM process sends attachments as base64 encoded streams.
> If the “original” for the attachment was already base64
> this is not done, but the “OriginalBase64” value is Yes.

In the Skeleton message case, the original was XML, so No is an
appropriate value.

In the examples provided within the spec, the Skeleton messages
are also with No.

> Filename="EEB93039-4285-4937-AEDB-18844C14DC9inps.co.ukVision3.gzip"
> ContentType=text/xml Compressed=No LargeAttachment=No OriginalBase64=No
> Length=302448 DomainData="X-GP2GP-Skeleton: Yes"

SystmOne also provide a value of No when sending their Skeleton message out.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
