### PR TITLE
Changing hashmap data structures to safer concurrent-friendly alterna…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Previously, a NOT_AUTHORISED (401) response from [`/$gpc.migratestructuredrecord`][migrate-structured-record] would generate a NACK with code 19.
   This behaviour has now been removed and instead a response type of NO_RELATIONSHIP (403) will produce NACK with code 19.
-- HashMap has been replaced with more efficient ConcurrentHashMap
+- Some data structures have been replaced with more efficient concurrent version to avoid any potential side effects
 
 [migrate-structured-record]: https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_migrate_patient_record.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Previously, a NOT_AUTHORISED (401) response from [`/$gpc.migratestructuredrecord`][migrate-structured-record] would generate a NACK with code 19.
   This behaviour has now been removed and instead a response type of NO_RELATIONSHIP (403) will produce NACK with code 19.
+- HashMap has been replaced with more efficient ConcurrentHashMap
 
 [migrate-structured-record]: https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_migrate_patient_record.html
 

--- a/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/controller/MhsMockController.java
+++ b/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/controller/MhsMockController.java
@@ -7,10 +7,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -43,7 +43,7 @@ public class MhsMockController {
     private final MDCService mdcService;
     private final HttpHeaders responseHeaders = new HttpHeaders();
 
-    private static final Map<String, List<String>> REQUEST_JOURNALS_MAP = new HashMap<>();
+    private static final Map<String, List<String>> REQUEST_JOURNALS_MAP = new ConcurrentHashMap<>();
 
     @GetMapping(value = "/mock-mhs-endpoint/healthcheck")
     @ResponseStatus(value = HttpStatus.OK)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/storage/LocalMockConnector.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/storage/LocalMockConnector.java
@@ -3,14 +3,14 @@ package uk.nhs.adaptors.gp2gp.common.storage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class LocalMockConnector implements StorageConnector {
     private final Map<String, byte[]> storage;
 
     protected LocalMockConnector() {
-        storage = new HashMap<>();
+        storage = new ConcurrentHashMap<>();
     }
 
     @Override

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AgentDirectory.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AgentDirectory.java
@@ -1,8 +1,8 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Bundle;
@@ -22,7 +22,7 @@ import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 @AllArgsConstructor
 public class AgentDirectory {
     private final RandomIdGeneratorService randomIdGeneratorService;
-    private final Map<AgentKey, String> agentDirectory = new HashMap<>();
+    private final Map<AgentKey, String> agentDirectory = new ConcurrentHashMap<>();
     private final Bundle inputBundle;
 
     public Set<Map.Entry<AgentKey, String>> getEntries() {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/IdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/IdMapper.java
@@ -2,9 +2,9 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
 import lombok.AllArgsConstructor;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -21,7 +21,7 @@ import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 @AllArgsConstructor
 public class IdMapper {
     private final RandomIdGeneratorService randomIdGeneratorService;
-    private final Map<String, MappedId> ids = new HashMap<>();
+    private final Map<String, MappedId> ids = new ConcurrentHashMap<>();
     private static final Set<String> NOT_ALLOWED = Set.of(
         ResourceType.Organization.name(),
         ResourceType.Practitioner.name(),

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationRequestIdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationRequestIdMapper.java
@@ -1,7 +1,7 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +11,7 @@ import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 public class MedicationRequestIdMapper {
     private final RandomIdGeneratorService randomIdGeneratorService;
     @NonNull
-    private final Map<String, String> ids = new HashMap<>();
+    private final Map<String, String> ids = new ConcurrentHashMap<>();
 
     public String getOrNew(String id) {
         return ids.computeIfAbsent(id, $ -> randomIdGeneratorService.createNewId());


### PR DESCRIPTION

## What

Hashmap data structure has been replaced with a safer and more efficient (in concurrency environment) ConcurrentHashMap.

## Why

ConcurrentHashMap performs far better when dealing with multiple threads so we want to be on the safe side and use concurrency efficient map in the environment in order to minimize the risk of the occurrence of related risks.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
