### PR TITLE
Remove duplicated logging

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GpcClient.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GpcClient.java
@@ -60,12 +60,6 @@ public class GpcClient {
 
     private String performRequest(WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> request) {
         var response = request.retrieve();
-        if (LOGGER.isDebugEnabled()) {
-            var responseBody = response.bodyToMono(String.class).block();
-            LOGGER.debug("Body: {}", responseBody);
-            return responseBody;
-        }
-
         return response.bodyToMono(String.class).block();
     }
 


### PR DESCRIPTION
## Why

Each call to `performRequest` already has a DEBUG logger which prints out the full request.

This means that the full request body was being printed out twice. Printing full request bodies is very slow for several MB attachments

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
